### PR TITLE
SafeguardSessions\Request.pqm: Fix mock in Request.Generate

### DIFF
--- a/SafeguardSessions/Request.pqm
+++ b/SafeguardSessions/Request.pqm
@@ -29,12 +29,12 @@ let
     Request.Generate = (url as text, parameters as record, optional mocks as record) as record =>
         let
             response =
-                if Record.HasFields(mocks, "Response") then
+                if mocks <> null and Record.HasFields(mocks, "Response") then
                     mocks[Response]
                 else
-                    Json.Document(Web.Contents(url, parameters)),
+                    Web.Contents(url, parameters),
             _meta = Value.Metadata(response),
-            _table = Table.FromRecords({response})
+            _table = Table.FromRecords({Json.Document((response))})
         in
             [
                 Data = _table,

--- a/SafeguardSessions/test/TestRequest.query.pq
+++ b/SafeguardSessions/test/TestRequest.query.pq
@@ -39,7 +39,7 @@ requestMetaData = [
 
 TestRequestGeneration = () =>
     let
-        fakeresponse = FakeJsonResponse("{""dummy_field"": ""value"", ""dummy_list"": [0, 1, 2]}"),
+        fakeresponse = FakeResponse("{""dummy_field"": ""value"", ""dummy_list"": [0, 1, 2]}"),
         expected_body = #table(type table [dummy_field = any, dummy_list = any], {{"value", {0, 1, 2}}}),
         expected_meta = [Content.Type = "application/json", Response.Status = 200],
         response = Request.Generate("dummy_url", [], [Response = fakeresponse]),

--- a/SafeguardSessions/test/UnitTestFramework.pq
+++ b/SafeguardSessions/test/UnitTestFramework.pq
@@ -245,9 +245,9 @@ ValueToText = (value, optional depth) =>
     in
         try Serialize(value) otherwise "<serialization failed>";
 
-shared FakeJsonResponse = (body as text, optional metadata as record) =>
+shared FakeResponse = (body as text, optional metadata as record) =>
     let
-        response = Json.Document(body),
+        response = Text.ToBinary(body),
         response_with_meta = Value.ReplaceMetadata(
             response, if metadata <> null then metadata else [
                 Content.Type = "application/json",


### PR DESCRIPTION
So far, all Request.Generate calls have executed the mocked version. As a result, when we ran a query on actual real-world data, we received an error. This has been fixed so that we only get to the mocked path of the function if it gets a mocks parameter.