### PR TITLE
SafeguardSessions\SafeguardSessions.pq:  Change connector's data

### DIFF
--- a/SafeguardSessions/SafeguardSessions.pq
+++ b/SafeguardSessions/SafeguardSessions.pq
@@ -26,7 +26,7 @@ ContentsImpl = (url as text) =>
         authResponse = Request.Generate(url, Request.GetAuthParameters(encodedCredentails)),
         cookie = Request.GetHeader(authResponse[RequestMetaData], "Set-Cookie"),
         sessionId = BaseAuthentication.GetSessionId(cookie),
-        response = Request.Generate(url, Request.GetDefaultParameters("info", sessionId))
+        response = Request.Generate(url, Request.GetDefaultParameters("audit/sessions", sessionId))
     in
         response[Data];
 


### PR DESCRIPTION
query endpoint

Changed the route of the connector data request. The connector now queries the SPS REST API audit/sessions endpoint instead of the  info endpoint.

References: azure #365995