### PR TITLE
sps: Add error handling

### DIFF
--- a/SafeguardSessions/SafeguardSessions.pq
+++ b/SafeguardSessions/SafeguardSessions.pq
@@ -25,16 +25,53 @@ ContentsImpl = (sps_ip as text) =>
     in
         data;
 
-shared GetData = (url as text, credentials as record, optional mocks as record) =>
+shared GetData = (base_url as text, credentials as record, optional mocks as record) =>
     let
-        authResponse = Authenticate(url, credentials, mocks),
-        response = FetchData(
-            url,
-            BaseAuthentication.MineSessionIdFromCookie(Request.GetHeader(Value.Metadata(authResponse), "Set-Cookie")),
-            mocks
-        )
+        _start_time = DateTime.LocalNow(),
+        auth_url = Uri.Combine(base_url, "authentication"),
+        fetch_url = Uri.Combine(base_url, "audit/sessions"),
+        authResponse = (try Authenticate(auth_url, credentials, mocks)) meta [Url = auth_url],
+        response =
+            if authResponse[HasError] then
+                authResponse
+            else
+                (
+                    try
+                        FetchData(
+                            fetch_url,
+                            BaseAuthentication.MineSessionIdFromCookie(
+                                Request.GetHeader(Value.Metadata(authResponse[Value]), "Set-Cookie")
+                            ),
+                            mocks
+                        )
+                ) meta [Url = fetch_url],
+        result =
+            if response[HasError] then
+                ErrorLog(
+                    "Error response of the http request",
+                    SPSResult(
+                        response[Error],
+                        FetchInfo(
+                            ErrorStatus, response[Error][Message], _start_time, 0, true, Value.Metadata(
+                                response
+                            )[Url]
+                        )
+                    )
+                )
+            else
+                SPSResult(
+                    response[Value],
+                    FetchInfo(
+                        SuccessStatus,
+                        "Data fetch succeeded",
+                        _start_time,
+                        Table.RowCount(response[Value]),
+                        false,
+                        Value.Metadata(response)[Url]
+                    )
+                )
     in
-        response;
+        result;
 
 shared Authenticate = (url as text, credentials as record, optional mocks as nullable record) as table =>
     let
@@ -47,19 +84,17 @@ shared Authenticate = (url as text, credentials as record, optional mocks as nul
             else
                 Request.Generate(url, Request.GetAuthParameters(encodedCredentails))
     in
-        response;
+        RaiseErrorOrReturn(response);
 
 shared FetchData = (url as text, session_id as text, optional mocks as nullable record) as table =>
     let
         response =
             if IsMocked(mocks, "FetchResponse") then
-                Request.Generate(
-                    url, Request.GetDefaultParameters("audit/sessions", session_id), [Response = mocks[FetchResponse]]
-                )
+                Request.Generate(url, Request.GetDefaultParameters(session_id), [Response = mocks[FetchResponse]])
             else
-                Request.Generate(url, Request.GetDefaultParameters("audit/sessions", session_id))
+                Request.Generate(url, Request.GetDefaultParameters(session_id))
     in
-        response;
+        RaiseErrorOrReturn(response);
 
 SafeguardSessions = [
     Authentication = [
@@ -108,11 +143,21 @@ shared Extension.ImportModule = (name as text) =>
 shared Extension.ImportFunction = (function_name as text, module_name as text) =>
     Record.Field(Extension.ImportModule(module_name), function_name);
 
-IsMocked = Extension.ImportFunction("IsMocked", "Utils.pqm");
+Utils = Extension.ImportModule("Utils.pqm");
+
+IsMocked = Utils[IsMocked];
+FetchInfo = Utils[FetchInfo];
+SPSResult = Utils[SPSResult];
+SuccessStatus = Utils[SuccessStatus];
+ErrorStatus = Utils[ErrorStatus];
+ErrorLog = Utils[ErrorLog];
+
 BaseAuthentication = Extension.ImportModule("BaseAuthentication.pqm");
 
 BaseAuthentication.EncodeCredentials = BaseAuthentication[EncodeCredentials];
 BaseAuthentication.MineSessionIdFromCookie = BaseAuthentication[MineSessionIdFromCookie];
+
+RaiseErrorOrReturn = Extension.ImportFunction("RaiseErrorOrReturn", "CustomErrors.pqm");
 
 Request = Extension.ImportModule("Request.pqm");
 

--- a/SafeguardSessions/SafeguardSessions.proj
+++ b/SafeguardSessions/SafeguardSessions.proj
@@ -9,8 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <MezContent Include="$(ModulesPath)BaseAuthentication.pqm" />
-    <MezContent Include="$(ModulesPath)Utils.pqm" />
+    <MezContent Include="$(ModulesPath)CustomErrors.pqm" />
     <MezContent Include="$(ModulesPath)Request.pqm" />
+    <MezContent Include="$(ModulesPath)Utils.pqm" />
     <MezContent Include="SafeguardSessions.pq" />
     <MezContent Include="SafeguardSessions16.png" />
     <MezContent Include="SafeguardSessions20.png" />

--- a/SafeguardSessions/modules/CustomErrors.pqm
+++ b/SafeguardSessions/modules/CustomErrors.pqm
@@ -1,0 +1,57 @@
+let
+    CustomErrors.ErrorBase = Value.ReplaceType(CustomErrors.ErrorBaseImplementation, CustomErrors.ErrorBaseType),
+    CustomErrors.ErrorBaseImplementation = (reason as text, message as text, detail as anynonnull) =>
+        error [Reason = reason, Message = message, Detail = detail],
+    CustomErrors.ErrorBaseType = type function (
+        reason as (
+            type text meta [
+                Documentation.FieldCaption = "Error reason",
+                Documentation.FieldDescription = "Reason for the error"
+            ]
+        ),
+        message as (
+            type text meta [
+                Documentation.FieldCaption = "Error message",
+                Documentation.FieldDescription = "Descriptive message of the error"
+            ]
+        ),
+        detail as (
+            type anynonnull meta [
+                Documentation.FieldCaption = "Error details",
+                Documentation.FieldDescription = "Details of the error"
+            ]
+        )
+    ) as table meta [
+        Documentation.Name = "ErrorBase"
+    ],
+    CustomErrors.BadRequest = (detail as anynonnull) =>
+        CustomErrors.ErrorBase("Bad Request", "SPS interpreted a malformed request", detail),
+    CustomErrors.AuthenticationError = (detail as anynonnull) =>
+        CustomErrors.ErrorBase("Authentication Error", "Something went wrong while authenticating", detail),
+    CustomErrors.NotFound = (detail as anynonnull) =>
+        CustomErrors.ErrorBase("Not Found", "The requested resource cannot be found", detail),
+    CustomErrors.SnapshotQuotaError = (detail as anynonnull) =>
+        CustomErrors.ErrorBase("Snapshot Quota Error", "Snapshot quota exceeded", detail),
+    CustomErrors.GeneralError = (detail as anynonnull) =>
+        CustomErrors.ErrorBase("General Error", "SPS responded with server error", detail),
+    CustomErrors.ErrorMap = [
+        400 = CustomErrors.BadRequest,
+        401 = CustomErrors.AuthenticationError,
+        404 = CustomErrors.NotFound,
+        429 = CustomErrors.SnapshotQuotaError,
+        500 = CustomErrors.GeneralError
+    ],
+    CustomErrors.RaiseErrorOrReturn = (response as any, optional details as any) =>
+        let
+            _field = Text.From(Value.Metadata(response)[Response.Status]),
+            _details = if details <> null then details else response
+        in
+            if Record.HasFields(CustomErrors.ErrorMap, _field) then
+                Record.Field(CustomErrors.ErrorMap, _field)(_details)
+            else
+                response
+in
+    [
+        ErrorCodes = List.Transform(Record.FieldNames(CustomErrors.ErrorMap), each Number.FromText(_)),
+        RaiseErrorOrReturn = CustomErrors.RaiseErrorOrReturn
+    ]

--- a/SafeguardSessions/modules/Request.pqm
+++ b/SafeguardSessions/modules/Request.pqm
@@ -1,10 +1,10 @@
 let
     IsMocked = Extension.ImportFunction("IsMocked", "Utils.pqm"),
     InfoLog = Extension.ImportFunction("InfoLog", "Utils.pqm"),
+    ErrorCodes = Extension.ImportFunction("ErrorCodes", "CustomErrors.pqm"),
     Request.GetAuthParameters = (encodedCredentails as text) as record =>
         let
             parameters = [
-                RelativePath = "authentication",
                 Query = [return = "/api/authentication"],
                 Headers = [
                     #"Authorization" = Text.Combine({"Basic ", encodedCredentails}),
@@ -15,10 +15,9 @@ let
             ]
         in
             parameters,
-    Request.GetDefaultParameters = (path as text, sessionId as text) as record =>
+    Request.GetDefaultParameters = (sessionId as text) as record =>
         let
             parameters = [
-                RelativePath = path,
                 Headers = [
                     #"Accept" = "application/json",
                     #"Connection" = "keep-alive",
@@ -32,7 +31,11 @@ let
         let
             requestUrl = InfoLog("Base url of the http request", url),
             requestParameters = InfoLog("Request parameters of the http request", parameters),
-            response = if IsMocked(mocks, "Response") then mocks[Response] else Web.Contents(url, parameters),
+            response =
+                if IsMocked(mocks, "Response") then
+                    mocks[Response]
+                else
+                    Web.Contents(url, Record.AddField(parameters, "ManualStatusHandling", ErrorCodes)),
             _meta = InfoLog("Response meta data of the http request", Value.Metadata(response)),
             _json = InfoLog("Response data of the http request", Json.Document((response))),
             _table = Table.FromRecords({_json})

--- a/SafeguardSessions/modules/Utils.pqm
+++ b/SafeguardSessions/modules/Utils.pqm
@@ -213,9 +213,35 @@ let
     Utils.InfoLog = (
         prefix as text, value as any, optional delayed as nullable logical, optional isTesting as nullable logical
     ) =>
-        Utils.LogWrapper(TraceLevel.Information, prefix, value, delayed, isTesting)
+        Utils.LogWrapper(TraceLevel.Information, prefix, value, delayed, isTesting),
+    Utils.ErrorLog = (
+        prefix as text, value as any, optional delayed as nullable logical, optional isTesting as nullable logical
+    ) =>
+        Utils.LogWrapper(TraceLevel.Error, prefix, value, delayed, isTesting),
+    Utils.FetchInfo = (
+        status as text, message as text, start as nullable datetime, count as number, failed as logical, url as text
+    ) as table =>
+        Table.FromRecords(
+            {[
+                Start = start,
+                Url = url,
+                Status = status,
+                Count = count,
+                Message = message,
+                Failed = failed
+            ]}
+        ),
+    Utils.SPSResult = (session_data as anynonnull, additional_info as table) =>
+        [SessionData = session_data, FetchInfo = additional_info],
+    Utils.SuccessStatus = "Success",
+    Utils.ErrorStatus = "Error"
 in
     [
         IsMocked = Utils.IsMocked,
-        InfoLog = Utils.InfoLog
+        InfoLog = Utils.InfoLog,
+        ErrorLog = Utils.ErrorLog,
+        FetchInfo = Utils.FetchInfo,
+        SPSResult = Utils.SPSResult,
+        SuccessStatus = Utils.SuccessStatus,
+        ErrorStatus = Utils.ErrorStatus
     ]

--- a/SafeguardSessions/test/TestCustomErrors.query.pq
+++ b/SafeguardSessions/test/TestCustomErrors.query.pq
@@ -1,0 +1,68 @@
+section TestCustomErrors;
+
+RaiseErrorOrReturn = Extension.ImportFunction("RaiseErrorOrReturn", "CustomErrors.pqm");
+ErrorCodes = Extension.ImportFunction("ErrorCodes", "CustomErrors.pqm");
+
+TestRaiseErrorOrReturnRaisesError = () =>
+    let
+        fake_auth_response = FakeResponse("{""error"": ""reason""}", [
+            Response.Status = 401
+        ]),
+        facts = TestErrorIsRaised(
+            try RaiseErrorOrReturn(fake_auth_response),
+            "Authentication Error",
+            "Something went wrong while authenticating",
+            fake_auth_response
+        )
+    in
+        facts;
+
+TestRaiseErrorOrReturnRaisesErrorWithDetails = () =>
+    let
+        fake_auth_response = FakeResponse("{}", [
+            Response.Status = 401
+        ]),
+        details = "dummy details",
+        facts = TestErrorIsRaised(
+            try RaiseErrorOrReturn(fake_auth_response, details),
+            "Authentication Error",
+            "Something went wrong while authenticating",
+            "dummy details"
+        )
+    in
+        facts;
+
+TestRaiseErrorOrReturnFallbackIsWorking = () =>
+    let
+        fake_response = FakeResponse("{""key"": ""value""}"),
+        response = RaiseErrorOrReturn(fake_response),
+        facts = {
+            Fact("Response data correct", fake_response, response),
+            Fact(
+                "Response meta is correct",
+                [
+                    Content.Type = "application/json",
+                    Response.Status = 200
+                ],
+                Value.Metadata(response)
+            )
+        }
+    in
+        facts;
+
+TestErrorCodeListIsCorrect = () =>
+    let
+        expected_error_code_list = {400, 401, 404, 429, 500},
+        fact = Fact("Error code list is correct", expected_error_code_list, ErrorCodes)
+    in
+        fact;
+
+shared TestCustomErrors.UnitTest = [
+    facts = {
+        TestRaiseErrorOrReturnRaisesError(),
+        TestRaiseErrorOrReturnRaisesErrorWithDetails(),
+        TestRaiseErrorOrReturnFallbackIsWorking(),
+        TestErrorCodeListIsCorrect()
+    },
+    report = Facts.Summarize(facts)
+][report];

--- a/SafeguardSessions/test/TestLogger.query.pq
+++ b/SafeguardSessions/test/TestLogger.query.pq
@@ -3,6 +3,9 @@ section TestUtils;
 Utils = Extension.ImportModule("Utils.pqm");
 
 Utils.InfoLog = Utils[InfoLog];
+Utils.ErrorLog = Utils[ErrorLog];
+Utils.SPSResult = Utils[SPSResult];
+Utils.FetchInfo = Utils[FetchInfo];
 
 TestInfoLogWithNumberInput = () =>
     let
@@ -64,18 +67,48 @@ TestInfoLogWithTableInput = () =>
     let
         input = [
             Prefix = "say",
-            Value = #table(type table [#"Number" = number, #"Value" = text], {{1, "Apple Tree"}, {2, "Ladybug"}, {3, "Little ducks"}}),
+            Value = #table(
+                type table [#"Number" = number, #"Value" = text],
+                {{1, "Apple Tree"}, {2, "Ladybug"}, {3, "Little ducks"}}
+            ),
             Delayed = null,
             IsTesting = true
         ],
         expectedLogValues = [
             LogLevel = TraceLevel.Information,
             Output = "say: #table( type table [Number = number, Value = text] , {{1, ""Apple Tree""} , {2, ""Ladybug""} , {3, ""Little ducks""} } ) ",
-            Value = #table({"Number", "Value"}, {{1, "Apple Tree"}, {2, "Ladybug"}, {3, "Little ducks"} }),
+            Value = #table({"Number", "Value"}, {{1, "Apple Tree"}, {2, "Ladybug"}, {3, "Little ducks"}}),
             Delayed = null
         ],
         logValues = Utils.InfoLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
         facts = TestLogging(logValues, expectedLogValues, "table")
+    in
+        facts;
+
+TestErrorLogWithSPSResultInput = () =>
+    let
+        input = [
+            Prefix = "error",
+            Value = Utils.SPSResult(
+                "error", Utils.FetchInfo("status", "message", #datetime(2023, 1, 18, 9, 47, 55), 42, true, "query")
+            ),
+            Delayed = null,
+            IsTesting = true
+        ],
+        expectedLogValues = [
+            LogLevel = TraceLevel.Error,
+            Output = "error: [ SessionData = ""error"", FetchInfo = #table( type table [Start = any, Query = any, Status = any, Count = any, Message = any, Failed = any] , {{#datetime(2023, 1, 18, 9, 47, 55), ""query"", ""status"", 42, ""message"", true} } )  ] ",
+            Value = [
+                SessionData = "error",
+                FetchInfo = #table(
+                    type table [Start = any, Query = any, Status = any, Count = any, Message = any, Failed = any],
+                    {{#datetime(2023, 1, 18, 9, 47, 55), "query", "status", 42, "message", true}}
+                )
+            ],
+            Delayed = null
+        ],
+        logValues = Utils.ErrorLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
+        facts = TestLogging(logValues, expectedLogValues, "SPSResult")
     in
         facts;
 
@@ -85,7 +118,8 @@ shared TestUtils.UnitTest = [
         TestInfoLogWithTextInput(),
         TestInfoLogWithListInput(),
         TestInfoLogWithRecordInput(),
-        TestInfoLogWithTableInput()
+        TestInfoLogWithTableInput(),
+        TestErrorLogWithSPSResultInput()
     },
     report = Facts.Summarize(facts)
 ][report];

--- a/SafeguardSessions/test/TestRequest.query.pq
+++ b/SafeguardSessions/test/TestRequest.query.pq
@@ -8,40 +8,9 @@ Request.Generate = Request[Generate];
 Request.GetHeader = Request[GetHeader];
 
 requestMetaData = [
-    Content.Type = "application/json",
-    Content.Uri = "[Function]",
-    Content.Name = " 10.12.230.132",
     Headers = [
-        Connection = "keep-alive",
-        #"Content-Language" = "en",
-        Allow = "GET",
-        #"X-Frame-Options" = "SAMEORIGIN,SAMEORIGIN",
-        #"Content-Security-Policy" = "frame-ancestors 'self',object-src 'none'; img-src 'self' data:; font-src 'self' data:",
-        #"Cross-Origin-Resource-Policy" = "same-origin",
-        Pragma = "no-cache",
-        #"Content-Disposition" = "attachment; filename=response",
-        #"X-Content-Type-Options" = "nosniff",
-        #"Referrer-Policy" = "same-origin",
-        #"X-XSS-Protection" = "1; mode=block",
-        #"Strict-Transport-Security" = "max-age=31536000; includeSubDomains",
-        #"Content-Length" = "915",
-        #"Cache-Control" = "no-cache, no-store",
-        #"Content-Type" = "application/json",
-        Date = "Fri, 02 Dec 2022 14:27:48 GMT",
-        Expires = "0",
-        #"Set-Cookie" = "session_id=e8e5f0a0d3367043150187f81df3484e91e365d5; expires=Sat, 03 Dec 2022 02:27:48 GMT; HttpOnly; Max-Age=43200; Path=/; Secure",
-        Server = "REST"
-    ],
-    Request.Options = [
-        RelativePath = "info",
-        Headers = [
-            Accept = "application/json",
-            Connection = "keep-alive",
-            Cookie = "session_id=e4d836546263b4983d9c9537dfb2fe8119ab89f1"
-        ],
-        IsRetry = true
-    ],
-    Response.Status = 200
+        #"Set-Cookie" = "session_id=e8e5f0a0d3367043150187f81df3484e91e365d5; expires=Sat, 03 Dec 2022 02:27:48 GMT; HttpOnly; Max-Age=43200; Path=/; Secure"
+    ]
 ];
 
 TestRequestGeneration = () =>
@@ -62,7 +31,6 @@ shared TestRequest.UnitTest = [
         Fact(
             "Check authentication request parameters:",
             [
-                RelativePath = "authentication",
                 Query = [return = "/api/authentication"],
                 Headers = [
                     #"Authorization" = "Basic YWxtYTpzemlsdmE=",
@@ -76,7 +44,6 @@ shared TestRequest.UnitTest = [
         Fact(
             "Check default request parameters:",
             [
-                RelativePath = "info",
                 Headers = [
                     #"Accept" = "application/json",
                     #"Connection" = "keep-alive",
@@ -84,7 +51,7 @@ shared TestRequest.UnitTest = [
                 ],
                 IsRetry = true
             ],
-            Request.GetDefaultParameters("info", "session_id=47710719df1849b5b6aa2fd301e32a216cffe38b")
+            Request.GetDefaultParameters("session_id=47710719df1849b5b6aa2fd301e32a216cffe38b")
         ),
         Fact(
             "Check request get header value:",

--- a/SafeguardSessions/test/TestSafeguardSessions.query.pq
+++ b/SafeguardSessions/test/TestSafeguardSessions.query.pq
@@ -1,6 +1,17 @@
 section TestSafeguardSessions;
 
-TestGetData = () =>
+FetchInfo = Extension.ImportFunction("FetchInfo", "Utils.pqm");
+
+TestResultsContentWithoutStartTime = (response as record, expected_data as any, expected_info as table) =>
+    let
+        facts = {
+            Fact("Data content of response matches", expected_data, response[SessionData]),
+            TestFetchInfoContentWithoutStartTime(expected_info, response[FetchInfo])
+        }
+    in
+        facts;
+
+TestGetDataWithoutError = () =>
     let
         fake_auth_response = FakeResponse(
             "{}",
@@ -12,8 +23,10 @@ TestGetData = () =>
             ]
         ),
         fake_response = FakeResponse("{""dummy_field"": ""value"", ""dummy_list"": [0, 1, 2]}"),
-        expected_body = #table(type table [dummy_field = any, dummy_list = any], {{"value", {0, 1, 2}}}),
-        expected_meta = [Content.Type = "application/json", Response.Status = 200],
+        expected_data = #table(type table [dummy_field = any, dummy_list = any], {{"value", {0, 1, 2}}}),
+        expected_info = FetchInfo(
+            "Success", "Data fetch succeeded", null, 1, false, "http://dummy_url/audit/sessions"
+        ),
         response = GetData(
             "dummy_url",
             [
@@ -24,15 +37,71 @@ TestGetData = () =>
                 AuthResponse = fake_auth_response,
                 FetchResponse = fake_response
             ]
-        ),
-        facts = {
-            Fact("Reponse data is correct", expected_body, response),
-            Fact("Reponse meta is correct", expected_meta, Value.Metadata(response))
-        }
+        )
     in
-        facts;
+        TestResultsContentWithoutStartTime(response, expected_data, expected_info);
 
-TestAuthenticate = () =>
+TestGetDataHandlesAuthenticationError = () =>
+    let
+        fake_auth_response = FakeResponse("{""error"": ""value""}", [
+            Response.Status = 401
+        ]),
+        expected_data = [
+            Reason = "Authentication Error",
+            Message = "Something went wrong while authenticating",
+            Detail = #table(type table [#"error" = any], {{"value"}}),
+            Message.Format = null,
+            Message.Parameters = null
+        ],
+        expected_info = FetchInfo(
+            "Error", "Something went wrong while authenticating", null, 0, true, "http://dummy_url/authentication"
+        ),
+        response = GetData("dummy_url", [
+            Username = "dummy",
+            Password = "pwd"
+        ], [
+            AuthResponse = fake_auth_response
+        ])
+    in
+        TestResultsContentWithoutStartTime(response, expected_data, expected_info);
+
+TestGetDataHandlesBadRequest = () =>
+    let
+        fake_auth_response = FakeResponse(
+            "{}",
+            [
+                Response.Status = 200,
+                Headers = [
+                    #"Set-Cookie" = "session_id=e8e5f0a0d3367043150187f81df3484e91e365d5; expires=Sat, 03 Dec 2022 02:27:48 GMT; HttpOnly; Max-Age=43200; Path=/; Secure"
+                ]
+            ]
+        ),
+        fake_response = FakeResponse("{""error"": ""value""}", [Response.Status = 500]),
+        expected_data = [
+            Reason = "General Error",
+            Message = "SPS responded with server error",
+            Detail = #table(type table [#"error" = any], {{"value"}}),
+            Message.Format = null,
+            Message.Parameters = null
+        ],
+        expected_info = FetchInfo(
+            "Error", "SPS responded with server error", null, 0, true, "http://dummy_url/audit/sessions"
+        ),
+        response = GetData(
+            "dummy_url",
+            [
+                Username = "dummy",
+                Password = "pwd"
+            ],
+            [
+                AuthResponse = fake_auth_response,
+                FetchResponse = fake_response
+            ]
+        )
+    in
+        TestResultsContentWithoutStartTime(response, expected_data, expected_info);
+
+TestAuthenticateIsSuccessful = () =>
     let
         fake_auth_response = FakeResponse(
             "{}",
@@ -67,24 +136,99 @@ TestAuthenticate = () =>
     in
         facts;
 
-TestFetchData = () =>
+TestAuthenticationRaisesErrorForStatusCode = (
+    status_code as number, expected_reason as text, expected_message as text
+) =>
     let
-        fake_response = FakeResponse("{""dummy_field"": ""value"", ""dummy_list"": [0, 1, 2]}", []),
-        response = FetchData("dummy_url", "e8e5f0a0d3367043150187f81df3484e91e365d5", [
-            FetchResponse = fake_response
+        fake_auth_response = FakeResponse("{""error"": ""reason""}", [
+            Response.Status = status_code
         ]),
+        facts = TestErrorIsRaised(
+            try
+                Authenticate(
+                    "dummy_url", [
+                        Username = "dummy",
+                        Password = "pwd"
+                    ], [
+                        AuthResponse = fake_auth_response
+                    ]
+                ),
+            expected_reason,
+            expected_message,
+            #table(type table [#"error" = any], {{"reason"}})
+        )
+    in
+        facts;
+
+TestAuthenticateRaisesError = () =>
+    let
+        cases = {
+            {401, "Authentication Error", "Something went wrong while authenticating"},
+            {500, "General Error", "SPS responded with server error"}
+        },
+        facts = ProvideDataForTest(cases, TestAuthenticationRaisesErrorForStatusCode)
+    in
+        facts;
+
+TestFetchDataIsSuccessful = () =>
+    let
+        fake_response = FakeResponse(
+            "{""dummy_field"": ""value"", ""dummy_list"": [0, 1, 2]}", [Response.Status = 200]
+        ),
+        response = FetchData(
+            "dummy_url", "e8e5f0a0d3367043150187f81df3484e91e365d5", [
+                FetchResponse = fake_response
+            ]
+        ),
         facts = {
             Fact(
                 "Data fetch response is correct",
                 #table(type table [dummy_field = any, dummy_list = any], {{"value", {0, 1, 2}}}),
                 response
             ),
-            Fact("Test data fetch meta is correct", [], Value.Metadata(response))
+            Fact("Test data fetch meta is correct", [Response.Status = 200], Value.Metadata(response))
         }
     in
         facts;
 
+TestFetchDataRaisesErrorForStatusCode = (status_code as number, expected_reason as text, expected_message as text) =>
+    let
+        fake_response = FakeResponse("{""error"": ""reason""}", [
+            Response.Status = status_code
+        ]),
+        facts = TestErrorIsRaised(
+            try FetchData("dummy_url", "e8e5f0a0d3367043150187f81df3484e91e365d5", [
+                FetchResponse = fake_response
+            ]),
+            expected_reason,
+            expected_message,
+            #table(type table [#"error" = any], {{"reason"}})
+        )
+    in
+        facts;
+
+TestFetchDataRaisesError = () =>
+    let
+        cases = {
+            {400, "Bad Request", "SPS interpreted a malformed request"},
+            {401, "Authentication Error", "Something went wrong while authenticating"},
+            {404, "Not Found", "The requested resource cannot be found"},
+            {429, "Snapshot Quota Error", "Snapshot quota exceeded"},
+            {500, "General Error", "SPS responded with server error"}
+        },
+        facts = ProvideDataForTest(cases, TestFetchDataRaisesErrorForStatusCode)
+    in
+        facts;
+
 shared TestSafeguardSessions.UnitTest = [
-    facts = {TestGetData(), TestAuthenticate(), TestFetchData()},
+    facts = {
+        TestGetDataWithoutError(),
+        TestGetDataHandlesAuthenticationError(),
+        TestGetDataHandlesBadRequest(),
+        TestAuthenticateIsSuccessful(),
+        TestAuthenticateRaisesError(),
+        TestFetchDataIsSuccessful(),
+        TestFetchDataRaisesError()
+    },
     report = Facts.Summarize(facts)
 ][report];

--- a/SafeguardSessions/test/UnitTestFramework.pq
+++ b/SafeguardSessions/test/UnitTestFramework.pq
@@ -3,7 +3,7 @@
 // https://learn.microsoft.com/en-us/power-query/handlingunittesting
 // Version 1.0.0 was exactly the same as Microsoft's framework. Above this version number,
 // it includes our changes and additions
-[Version = "1.3.0"]
+[Version = "1.4.0"]
 section UnitTestFramework;
 
 shared Fact = (_subject as text, _expected, _actual) as record =>
@@ -288,3 +288,15 @@ shared TestLogging = (logValues as record, expectedLogValues as record, inputTyp
         facts;
 
 shared ProvideDataForTest = (data as list, func as function) => List.Transform(data, each Function.Invoke(func, _));
+
+shared TestFetchInfoContentWithoutStartTime = (expected_info as table, actual_info as table) =>
+    let
+        facts = {
+            Fact("Status matches", List.First(expected_info[Status]), List.First(actual_info[Status])),
+            Fact("Message matches", List.First(expected_info[Message]), List.First(actual_info[Message])),
+            Fact("Count matches", List.First(expected_info[Count]), List.First(actual_info[Count])),
+            Fact("Failed matches", List.First(expected_info[Failed]), List.First(actual_info[Failed])),
+            Fact("URL matches", List.First(expected_info[Url]), List.First(actual_info[Url]))
+        }
+    in
+        facts;


### PR DESCRIPTION
Scope: SafeguardSessions/SafeguardSessions.pq

Error handling for SPS related errors have been implemented: custom errors and utility functions have been added to make error handling possible. Using the try-if method enables us to also handle built-in errors without a different handler.

References: azure #351703