### PR TITLE
sps: Add logger tests

### DIFF
--- a/SafeguardSessions/SafeguardSessions.pq
+++ b/SafeguardSessions/SafeguardSessions.pq
@@ -36,7 +36,7 @@ shared GetData = (url as text, credentials as record, optional mocks as record) 
     in
         response;
 
-shared Authenticate = (url as text, credentials as record, optional mocks as record) as table =>
+shared Authenticate = (url as text, credentials as record, optional mocks as nullable record) as table =>
     let
         encodedCredentails = BaseAuthentication.EncodeCredentials(credentials[Username], credentials[Password]),
         response =
@@ -49,7 +49,7 @@ shared Authenticate = (url as text, credentials as record, optional mocks as rec
     in
         response;
 
-shared FetchData = (url as text, session_id as text, mocks as record) as table =>
+shared FetchData = (url as text, session_id as text, optional mocks as nullable record) as table =>
     let
         response =
             if IsMocked(mocks, "FetchResponse") then

--- a/SafeguardSessions/modules/Utils.pqm
+++ b/SafeguardSessions/modules/Utils.pqm
@@ -1,7 +1,13 @@
 let
     Utils.IsMocked = (mocks as nullable record, field as text) as logical =>
         mocks <> null and Record.HasFields(mocks, field),
-    Utils.LogWrapper = (logLevel as number, prefix as text, value as any, optional delayed) =>
+    Utils.LogWrapper = (
+        logLevel as number,
+        prefix as text,
+        value as any,
+        optional delayed as nullable logical,
+        optional isTesting as nullable logical
+    ) =>
         let
             //From Microsoft TripPin 8-Diagnostics tutorial
             //Source: https://github.com/microsoft/DataConnectors/blob/master/samples/TripPin/8-Diagnostics/Diagnostics.pqm
@@ -192,11 +198,22 @@ let
                 in
                     try Serialize(value) otherwise "<serialization failed>"
         in
-            Diagnostics.Trace(
-                logLevel, prefix & ": " & (try _valueToText(value) otherwise "<error getting value>"), value, delayed
-            ),
-    Utils.InfoLog = (prefix as text, value as any, optional delayed) =>
-        Utils.LogWrapper(TraceLevel.Information, prefix, value, delayed)
+            if isTesting = null or isTesting = false then
+                Diagnostics.Trace(
+                    logLevel, prefix & ": " & (try _valueToText(value) otherwise "<error getting value>"), value,
+                    delayed
+                )
+            else
+                [
+                    LogLevel = logLevel,
+                    Output = prefix & ": " & (try _valueToText(value) otherwise "<error getting value>"),
+                    Value = value,
+                    Delayed = delayed
+                ],
+    Utils.InfoLog = (
+        prefix as text, value as any, optional delayed as nullable logical, optional isTesting as nullable logical
+    ) =>
+        Utils.LogWrapper(TraceLevel.Information, prefix, value, delayed, isTesting)
 in
     [
         IsMocked = Utils.IsMocked,

--- a/SafeguardSessions/test/TestLogger.query.pq
+++ b/SafeguardSessions/test/TestLogger.query.pq
@@ -1,0 +1,91 @@
+section TestUtils;
+
+Utils = Extension.ImportModule("Utils.pqm");
+
+Utils.InfoLog = Utils[InfoLog];
+
+TestInfoLogWithNumberInput = () =>
+    let
+        input = [Prefix = "iphone", Value = 12, Delayed = null, IsTesting = true],
+        expectedLogValues = [LogLevel = TraceLevel.Information, Output = "iphone: 12", Value = 12, Delayed = null],
+        logValues = Utils.InfoLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
+        facts = TestLogging(logValues, expectedLogValues, "number")
+    in
+        facts;
+
+TestInfoLogWithTextInput = () =>
+    let
+        input = [Prefix = "iphone", Value = "pro", Delayed = null, IsTesting = true],
+        expectedLogValues = [
+            LogLevel = TraceLevel.Information,
+            Output = "iphone: ""pro""",
+            Value = "pro",
+            Delayed = null
+        ],
+        logValues = Utils.InfoLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
+        facts = TestLogging(logValues, expectedLogValues, "text")
+    in
+        facts;
+
+TestInfoLogWithListInput = () =>
+    let
+        input = [Prefix = "iphone", Value = {11, 12, 13}, Delayed = null, IsTesting = true],
+        expectedLogValues = [
+            LogLevel = TraceLevel.Information,
+            Output = "iphone: {11, 12, 13} ",
+            Value = {11, 12, 13},
+            Delayed = null
+        ],
+        logValues = Utils.InfoLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
+        facts = TestLogging(logValues, expectedLogValues, "list")
+    in
+        facts;
+
+TestInfoLogWithRecordInput = () =>
+    let
+        input = [
+            Prefix = "say",
+            Value = [One = "Apple tree", Two = "Ladybug", Three = "Little ducks"],
+            Delayed = null,
+            IsTesting = true
+        ],
+        expectedLogValues = [
+            LogLevel = TraceLevel.Information,
+            Output = "say: [ One = ""Apple tree"", Two = ""Ladybug"", Three = ""Little ducks"" ] ",
+            Value = [One = "Apple tree", Two = "Ladybug", Three = "Little ducks"],
+            Delayed = null
+        ],
+        logValues = Utils.InfoLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
+        facts = TestLogging(logValues, expectedLogValues, "record")
+    in
+        facts;
+
+TestInfoLogWithTableInput = () =>
+    let
+        input = [
+            Prefix = "say",
+            Value = #table(type table [#"Number" = number, #"Value" = text], {{1, "Apple Tree"}, {2, "Ladybug"}, {3, "Little ducks"}}),
+            Delayed = null,
+            IsTesting = true
+        ],
+        expectedLogValues = [
+            LogLevel = TraceLevel.Information,
+            Output = "say: #table( type table [Number = number, Value = text] , {{1, ""Apple Tree""} , {2, ""Ladybug""} , {3, ""Little ducks""} } ) ",
+            Value = #table({"Number", "Value"}, {{1, "Apple Tree"}, {2, "Ladybug"}, {3, "Little ducks"} }),
+            Delayed = null
+        ],
+        logValues = Utils.InfoLog(input[Prefix], input[Value], input[Delayed], input[IsTesting]),
+        facts = TestLogging(logValues, expectedLogValues, "table")
+    in
+        facts;
+
+shared TestUtils.UnitTest = [
+    facts = {
+        TestInfoLogWithNumberInput(),
+        TestInfoLogWithTextInput(),
+        TestInfoLogWithListInput(),
+        TestInfoLogWithRecordInput(),
+        TestInfoLogWithTableInput()
+    },
+    report = Facts.Summarize(facts)
+][report];

--- a/SafeguardSessions/test/UnitTestFramework.pq
+++ b/SafeguardSessions/test/UnitTestFramework.pq
@@ -3,7 +3,7 @@
 // https://learn.microsoft.com/en-us/power-query/handlingunittesting
 // Version 1.0.0 was exactly the same as Microsoft's framework. Above this version number,
 // it includes our changes and additions
-[Version = "1.1.0"]
+[Version = "1.2.0"]
 section UnitTestFrameork;
 
 shared Fact = (_subject as text, _expected, _actual) as record =>
@@ -47,14 +47,14 @@ shared Facts.Summarize = (_facts as list) as table =>
             Details = Text.Format("#{0}% success rate", {rate})
         ],
         report = Table.FromRecords(List.Combine({{header}, simplifiedFactsList})),
-        _simplifyFactsList = (simplifiedFactsList as list) as list =>
+        _simplifyFactsList = (facts as list) as list =>
             let
                 simplifiedList = List.Accumulate(
-                    _facts,
+                    facts,
                     {},
                     (state, current) =>
                         if Value.Is(current, type list) = true then
-                            List.Combine({state, current})
+                            List.Combine({state, @_simplifyFactsList(current)})
                         else
                             List.Combine({state, {current}})
                 )
@@ -264,6 +264,17 @@ shared TestErrorIsRaised = (err as record, reason as text, message as text, deta
             Fact("Reason is correct", reason, err[Error][Reason]),
             Fact("Message is correct", message, err[Error][Message]),
             Fact("Detail is correct", detail, err[Error][Detail])
+        }
+    in
+        facts;
+
+shared TestLogging = (logValues as record, expectedLogValues as record, inputType as text) as list =>
+    let
+        facts = {
+            Fact("Log level is correct with " &  inputType & " input type", logValues[LogLevel], expectedLogValues[LogLevel]),
+            {Fact("Output is correct with " &  inputType & " input type", logValues[Output], expectedLogValues[Output])},
+            Fact("Value is correct with " &  inputType & " input type", logValues[Value], expectedLogValues[Value]),
+            Fact("Delayed is correct with " &  inputType & " input type", logValues[Delayed], expectedLogValues[Delayed])
         }
     in
         facts;


### PR DESCRIPTION
Scope: SafeguardSessions/test/TestLogger.query.pq

The logging functions have been extended with an isTesting logical parameter, which, if true, returns the corresponding logging values in a record and does not log to the logging file.

References: azure #395938