### PR TITLE
Add enforcement of merge strategy

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[merge]
+    ff = no
+    commit = no


### PR DESCRIPTION
Scope: .gitconfig

In order to make easier to merge locally new configuration file sets merge strategy.

`ff = no`
create a merge commit in all cases, even when the merge could instead be resolved as a fast-forward
`commit = no`
perform the merge and stop just before creating a merge commit,
helps get commit message right: `Merge pull request #<PR> from <repo>/<branch>`