### PR TITLE
sps: Add option to hide successful test cases

### DIFF
--- a/SafeguardSessions/Makefile
+++ b/SafeguardSessions/Makefile
@@ -12,6 +12,8 @@ TEST_PROJECT_CONFIG=$(TEST_CONNECTOR_DIR)\test.proj
 MAIN_CONNECTOR=bin\SafeguardSessions.mez
 TEST_FRAMEWORK=$(TEST_CONNECTOR_DIR)\bin\UnitTestFramework.mez
 
+SHORT?=true
+
 build:
 	MSBuild $(TEST_PROJECT_CONFIG) -t:Clean;BuildMez \
 	&& MSBuild $(MAIN_PROJECT_CONFIG) -t:Clean;BuildMez
@@ -20,6 +22,7 @@ unit-test:
 	PQTest run-test \
 	--extension $(MAIN_CONNECTOR) \
 	--extension $(TEST_FRAMEWORK) \
+	--environmentConfiguration short=$(SHORT) \
 	--queryFile $(test_file) \
 	--prettyPrint
 
@@ -27,5 +30,6 @@ unit-tests:
 	PQTest run-test \
 	--extension $(MAIN_CONNECTOR) \
 	--extension $(TEST_FRAMEWORK) \
+	--environmentConfiguration short=$(SHORT) \
 	--queryFile $(TEST_CONNECTOR_DIR) \
 	--prettyPrint

--- a/SafeguardSessions/test/UnitTestFramework.pq
+++ b/SafeguardSessions/test/UnitTestFramework.pq
@@ -3,7 +3,7 @@
 // https://learn.microsoft.com/en-us/power-query/handlingunittesting
 // Version 1.0.0 was exactly the same as Microsoft's framework. Above this version number,
 // it includes our changes and additions
-[Version = "1.4.0"]
+[Version = "1.4.1"]
 section UnitTestFramework;
 
 shared Fact = (_subject as text, _expected, _actual) as record =>
@@ -30,6 +30,7 @@ shared Facts = (_subject as text, _predicates as list) =>
 
 shared Facts.Summarize = (_facts as list) as table =>
     [
+        shortOutput = Text.Lower(Environment.FeatureSwitch("short", false)) = "true",
         simplifiedFactsList = _simplifyFactsList(_facts),
         Fact.CountSuccesses = (count, i) =>
             [
@@ -39,6 +40,10 @@ shared Facts.Summarize = (_facts as list) as table =>
         passed = List.Accumulate(simplifiedFactsList, 0, Fact.CountSuccesses),
         total = List.Count(simplifiedFactsList),
         format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+        outputFactList = if shortOutput then
+            List.Select(simplifiedFactsList, each not Text.StartsWith([Result], "Success"))
+        else
+            simplifiedFactsList,
         result = if passed = total then "Success" else "⛔",
         rate = Number.IntegerDivide(100 * passed, total),
         header = [
@@ -46,7 +51,7 @@ shared Facts.Summarize = (_facts as list) as table =>
             Notes = Text.Format(format, {passed, total - passed}),
             Details = Text.Format("#{0}% success rate", {rate})
         ],
-        report = Table.FromRecords(List.Combine({{header}, simplifiedFactsList})),
+        report = Table.FromRecords(List.Combine({{header}, outputFactList})),
         _simplifyFactsList = (facts as list) as list =>
             let
                 simplifiedList = List.Accumulate(


### PR DESCRIPTION
Scope: SafeguardSessions/test/UnitTestFramework.pq

As the conclusion of our discussion about the  output of PQTest, we decided to reduce it's verbosity and only show failed results by default. This behaviour can be suppressed by passing an environment variable `short=false` using the `--environmentConfiguration` option, or setting a `SHORT=false` variable, when running `make unit-tests` or `make unit-test` targets.

Actually the value of the variable can be any thing, but "true", due to it being passed as `Text`.

References: azure #399285