### PR TITLE
sps: Fix logger tests

### DIFF
--- a/SafeguardSessions/test/TestLogger.query.pq
+++ b/SafeguardSessions/test/TestLogger.query.pq
@@ -90,19 +90,20 @@ TestErrorLogWithSPSResultInput = () =>
         input = [
             Prefix = "error",
             Value = Utils.SPSResult(
-                "error", Utils.FetchInfo("status", "message", #datetime(2023, 1, 18, 9, 47, 55), 42, true, "query")
+                "error",
+                Utils.FetchInfo("status", "message", #datetimezone(2023, 1, 18, 9, 47, 55, 2, 0), 42, true, "query")
             ),
             Delayed = null,
             IsTesting = true
         ],
         expectedLogValues = [
             LogLevel = TraceLevel.Error,
-            Output = "error: [ SessionData = ""error"", FetchInfo = #table( type table [Start = any, Url = any, Status = any, Count = any, Message = any, Failed = any] , {{#datetime(2023, 1, 18, 9, 47, 55), ""query"", ""status"", 42, ""message"", true} } )  ] ",
+            Output = "error: [ SessionData = ""error"", FetchInfo = #table( type table [Start = any, Url = any, Status = any, Count = any, Message = any, Failed = any] , {{#datetimezone(2023, 1, 18, 9, 47, 55, 2, 0), ""query"", ""status"", 42, ""message"", true} } )  ] ",
             Value = [
                 SessionData = "error",
                 FetchInfo = #table(
                     type table [Start = any, Url = any, Status = any, Count = any, Message = any, Failed = any],
-                    {{#datetime(2023, 1, 18, 9, 47, 55), "query", "status", 42, "message", true}}
+                    {{#datetimezone(2023, 1, 18, 9, 47, 55, 2, 0), "query", "status", 42, "message", true}}
                 )
             ],
             Delayed = null


### PR DESCRIPTION
Scope: SafeguardSessions/test/TestLogger.query.pq

The TestErrorLogWithSPSResultInput failed, because it was not updated that the SPSResult returns a DateTimeZone value and not a plain DateTime.