### PR TITLE
sps: Fix default "short" flag of test framework

### DIFF
--- a/SafeguardSessions/test/UnitTestFramework.pq
+++ b/SafeguardSessions/test/UnitTestFramework.pq
@@ -30,7 +30,7 @@ shared Facts = (_subject as text, _predicates as list) =>
 
 shared Facts.Summarize = (_facts as list) as table =>
     [
-        shortOutput = Text.Lower(Environment.FeatureSwitch("short", false)) = "true",
+        shortOutput = Text.Lower(Environment.FeatureSwitch("short", "true")) = "true",
         simplifiedFactsList = _simplifyFactsList(_facts),
         Fact.CountSuccesses = (count, i) =>
             [


### PR DESCRIPTION
Scope: SafeguardSessions/test/UnitTestFramework.pq

Running PQTest w/o setting "short" environment variable using `--environmentConfiguration` argument resulted a conversion error, due to incorrect default value.