### PR TITLE
sps: Remove sensitive data from logs

### DIFF
--- a/SafeguardSessions/SafeguardSessions.pq
+++ b/SafeguardSessions/SafeguardSessions.pq
@@ -100,7 +100,7 @@ shared Authenticate = (url as text, credentials as record, optional mocks as nul
             else
                 Request.Generate(url, Request.GetAuthParameters(encodedCredentails))
     in
-        RaiseErrorOrReturn(response);
+        response;
 
 shared FetchData = (url as text, session_id as text, optional mocks as nullable record) as record =>
     let
@@ -110,7 +110,7 @@ shared FetchData = (url as text, session_id as text, optional mocks as nullable 
             else
                 Request.Generate(url, Request.GetDefaultParameters(session_id))
     in
-        RaiseErrorOrReturn(response);
+        response;
 
 HandleIfThereIsAnError = (input as record) =>
     if input[HasError] = true then
@@ -121,7 +121,7 @@ HandleIfThereIsAnError = (input as record) =>
                 error input[Error]
         else
             let
-                logNotExpectedError = Loggger.ErrorLog("An unexpected error happend during execution",input[Error])
+                logNotExpectedError = Logger.ErrorLog("An unexpected error happend during execution", input[Error])
             in
                 error logNotExpectedError
     else
@@ -186,8 +186,6 @@ BaseAuthentication = Extension.ImportModule("BaseAuthentication.pqm");
 BaseAuthentication.EncodeCredentials = BaseAuthentication[EncodeCredentials];
 BaseAuthentication.MineSessionIdFromCookie = BaseAuthentication[MineSessionIdFromCookie];
 
-RaiseErrorOrReturn = Extension.ImportFunction("RaiseErrorOrReturn", "RequestErrors.pqm");
-
 Request = Extension.ImportModule("Request.pqm");
 
 Request.GetAuthParameters = Request[GetAuthParameters];
@@ -201,4 +199,4 @@ UrlBuilder.GenerateBaseUrl = UrlBuilder[GenerateBaseUrl];
 UrlBuilder.GenerateUrl = UrlBuilder[GenerateUrl];
 UrlBuilder.GetDefaultQuery = UrlBuilder[GetDefaultQuery];
 
-Loggger.ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm");
+Logger.ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm");

--- a/SafeguardSessions/modules/error/RequestErrors.pqm
+++ b/SafeguardSessions/modules/error/RequestErrors.pqm
@@ -1,5 +1,6 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
+    ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm"),
     RequestErrors.BadRequest = (detail as record) =>
         ErrorBase("Bad Request", "SPS interpreted a malformed request", detail),
     RequestErrors.AuthenticationError = (detail as record) =>
@@ -22,16 +23,24 @@ let
     ],
     RequestErrors.RaiseErrorOrReturn = (response as record) =>
         let
-            _responseMeta = Value.Metadata(response),
-            _http_status = Text.From(_responseMeta[Response.Status]),
-            _details = [
+            responseMeta = Value.Metadata(response),
+            httpStatus = Text.From(responseMeta[Response.Status]),
+            log = ErrorLog(
+                "SPS returned with an error response",
+                [
+                    Response = response,
+                    Response.Status = responseMeta[Response.Status],
+                    RequestUrl = responseMeta[RequestUrl]
+                ]
+            ),
+            details = [
                 ManuallyHandled = true,
                 Cause = response,
-                RequestUrl = _responseMeta[RequestUrl]
+                RequestUrl = log[RequestUrl]
             ]
         in
-            if Record.HasFields(RequestErrors.ErrorMap, _http_status) then
-                Record.Field(RequestErrors.ErrorMap, _http_status)(_details)
+            if Record.HasFields(RequestErrors.ErrorMap, httpStatus) then
+                Record.Field(RequestErrors.ErrorMap, httpStatus)(details)
             else
                 response
 in

--- a/SafeguardSessions/modules/request/Request.pqm
+++ b/SafeguardSessions/modules/request/Request.pqm
@@ -1,7 +1,9 @@
 let
     IsMocked = Extension.ImportFunction("IsMocked", "Utils.pqm"),
     InfoLog = Extension.ImportFunction("InfoLog", "Logger.pqm"),
-    ErrorCodes = Extension.ImportFunction("ErrorCodes", "RequestErrors.pqm"),
+    RequestErrors = Extension.ImportModule("RequestErrors.pqm"),
+    ErrorCodes = RequestErrors[ErrorCodes],
+    RaiseErrorOrReturn = RequestErrors[RaiseErrorOrReturn],
     Request.GetAuthParameters = (encodedCredentails as text) as record =>
         let
             parameters = [
@@ -30,18 +32,22 @@ let
             parameters,
     Request.Generate = (url as text, parameters as record, optional mocks as record) as record =>
         let
-            requestUrl = InfoLog("Base url of the http request", url),
-            requestParameters = InfoLog("Request parameters of the http request", parameters),
+            loggedParameters =
+                if Record.HasFields(parameters, "Headers") then
+                    Record.RemoveFields(parameters, "Headers")
+                else
+                    parameters,
+            log = InfoLog("Request sent to SPS", [Url = url, Parameters = loggedParameters]),
             response =
                 if IsMocked(mocks, "Response") then
                     mocks[Response]
                 else
-                    Web.Contents(requestUrl, requestParameters & [ManualStatusHandling = ErrorCodes]),
-            _meta = InfoLog("Response meta data of the http request", Value.Metadata(response)),
-            _json = InfoLog("Response data of the http request", Json.Document((response))),
-            _extendedMeta = _meta & [RequestUrl = url]
+                    Web.Contents(log[Url], parameters & [ManualStatusHandling = ErrorCodes]),
+            json = Json.Document(response),
+            extendedMeta = Value.Metadata(response) & [RequestUrl = url],
+            responseWithMeta = Value.ReplaceMetadata(json, extendedMeta)
         in
-            Value.ReplaceMetadata(_json, _extendedMeta),
+            RaiseErrorOrReturn(responseWithMeta),
     Request.GetHeader = (requestMetaData as record, headerName as text) as text =>
         Record.Field(requestMetaData[Headers], headerName)
 in


### PR DESCRIPTION
Scope: SafeguardSessions/modules/error/RequestErrors.pqm

When logging full request and response data sensitive information like
session id was leaked. This change limits logged information and also
rationalizes response logging by restricting it to responses with error
status.

References: azure #399831