### PR TITLE
sps: Unify mocks

### DIFF
--- a/SafeguardSessions/SafeguardSessions.pq
+++ b/SafeguardSessions/SafeguardSessions.pq
@@ -43,7 +43,7 @@ shared FetchSessions = (
     filterValue2 as nullable text,
     filterField3 as nullable text,
     filterValue3 as nullable text,
-    optional mocks as record
+    optional mocks as nullable record
 ) =>
     let
         qParameterInputPairList = {

--- a/SafeguardSessions/modules/request/Request.pqm
+++ b/SafeguardSessions/modules/request/Request.pqm
@@ -4,7 +4,6 @@ let
     RequestErrors = Extension.ImportModule("RequestErrors.pqm"),
     ErrorCodes = Extension.ImportFunction("ErrorCodes", "RequestErrors.pqm"),
     ValidateByStatusCode = Extension.ImportFunction("ValidateByStatusCode", "ResponseHandler.pqm"),
-
     Request.GetAuthParameters = (encodedCredentails as text) as record =>
         let
             parameters = [
@@ -31,7 +30,7 @@ let
             ]
         in
             parameters,
-    Request.Generate = (url as text, parameters as record, optional mocks as record) as record =>
+    Request.Generate = (url as text, parameters as record, optional mocks as nullable record) as record =>
         let
             loggedParameters =
                 if Record.HasFields(parameters, "Headers") then


### PR DESCRIPTION
Scope: SafeguardSessions

The optional mocks parameter must be a nullable record to make it failproof while using the connector in a real environment..