### PR TITLE
sps: Fix flatten utility functions

### DIFF
--- a/SafeguardSessions/SafeguardSessions.proj
+++ b/SafeguardSessions/SafeguardSessions.proj
@@ -22,6 +22,7 @@
     <MezContent Include="$(ModulesPath)Search.pqm" />
     <MezContent Include="$(ModulesPath)Utils.pqm" />
     <MezContent Include="$(ErrorPath)ErrorBase.pqm" />
+    <MezContent Include="$(ErrorPath)SchemaTransformationErrors.pqm" />
     <MezContent Include="$(ErrorPath)QueryTransformErrors.pqm" />
     <MezContent Include="$(ErrorPath)RequestErrors.pqm" />
     <MezContent Include="$(RequestPath)UrlBuilder.pqm" />

--- a/SafeguardSessions/modules/error/QueryTransformErrors.pqm
+++ b/SafeguardSessions/modules/error/QueryTransformErrors.pqm
@@ -1,7 +1,11 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
     QueryTransformErrors.FilterFieldWithoutValue = (detail as record) =>
-        ErrorBase("Filter Field Without Value", "There is a field value missing from one or more of your filter fields.", detail)
+        ErrorBase(
+            "Filter Field Without Value",
+            "There is a field value missing from one or more of your filter fields.",
+            detail
+        )
 in
     [
         FilterFieldWithoutValue = QueryTransformErrors.FilterFieldWithoutValue

--- a/SafeguardSessions/modules/error/RequestErrors.pqm
+++ b/SafeguardSessions/modules/error/RequestErrors.pqm
@@ -1,11 +1,14 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
     ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm"),
-
     RequestErrors.NotParsableResponse = (detail as anynonnull) =>
         ErrorBase("Not Parsable Response", "The source IP returned a response with missing fields.", detail),
     RequestErrors.BadRequest = (detail as record) =>
-        ErrorBase("Bad Request", "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.", detail),
+        ErrorBase(
+            "Bad Request",
+            "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+            detail
+        ),
     RequestErrors.AuthenticationError = (detail as record) =>
         ErrorBase("Authentication Error", "The username or password you have specified is invalid.", detail),
     RequestErrors.AuthorizationError = (detail as record) =>

--- a/SafeguardSessions/modules/error/SchemaTransformationErrors.pqm
+++ b/SafeguardSessions/modules/error/SchemaTransformationErrors.pqm
@@ -1,0 +1,8 @@
+let
+    ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
+    SchemaTransformationErrors.ListToTextConversionError = (detail as record) =>
+        ErrorBase("List To Text Conversion Error", "The list contains other types than text.", detail)
+in
+    [
+        ListToTextConversionError = SchemaTransformationErrors.ListToTextConversionError
+    ]

--- a/SafeguardSessions/modules/schema/SchemaUtils.pqm
+++ b/SafeguardSessions/modules/schema/SchemaUtils.pqm
@@ -1,9 +1,41 @@
 let
     PaddedTable.FromRecords = Extension.ImportFunction("PaddedTable.FromRecords", "Utils.pqm"),
+    SchemaTransformationErrors.ListToTextConversionError = Extension.ImportFunction(
+        "ListToTextConversionError", "SchemaTransformationErrors.pqm"
+    ),
+    Logger.ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm"),
     SchemaUtils.NameColumn = "Name",
     SchemaUtils.TypeColumn = "Type",
     SchemaUtils.Header = {SchemaUtils.NameColumn, SchemaUtils.TypeColumn},
     SchemaUtils.CreateSchema = (fields as list) => #table(SchemaUtils.Header, fields),
+    SchemaUtils.ConvertListToText = (l as nullable list, fieldName as text) as nullable text =>
+        let
+            asText =
+                if l is list then
+                    try
+                        Text.Combine(l, ",")
+                    otherwise
+                        let
+                            log = Logger.ErrorLog(
+                                "List cannot be converted to text as it contains other types than text",
+                                [
+                                    FieldName = fieldName,
+                                    Value = l
+                                ]
+                            ),
+                            converted = SchemaTransformationErrors.ListToTextConversionError(
+                                [
+                                    ManuallyHandled = true,
+                                    Cause = Text.FromBinary(Json.FromValue(log[Value])),
+                                    RequestUrl = null
+                                ]
+                            )
+                        in
+                            converted
+                else
+                    l
+        in
+            asText,
     SchemaUtils.GetSessionItemsResponse = (response as nullable record) as list =>
         let
             defaultValue = {},
@@ -53,33 +85,39 @@ let
                 List.IsEmpty(SchemaUtils.FieldNamesOfType(listOfRecords, List.Type))
             }
         ),
+    SchemaUtils.FlattenLists = (asTable as table, fieldNames as list) as table =>
+        let
+            flattened = Table.Buffer(
+                Table.TransformColumns(
+                    asTable,
+                    List.Transform(
+                        fieldNames, (fieldName) =>
+                            {fieldName, (row) => SchemaUtils.ConvertListToText(row, fieldName)}
+                    )
+                )
+            )
+        in
+            flattened,
+    SchemaUtils.FlattenRecords = (asTable as table, fieldNames as list) as table =>
+        let
+            ExpandRecord = (asTable as table, fieldName as text) as any =>
+                let
+                    namesToExpand = List.Distinct(
+                        Record.FieldNames(Record.Combine(List.RemoveNulls(Table.Column(asTable, fieldName))))
+                    ),
+                    newNames = List.Transform(
+                        namesToExpand, (nameToExpand) => Text.Combine({fieldName, nameToExpand}, ".")
+                    ),
+                    expanded = Table.ExpandRecordColumn(asTable, fieldName, namesToExpand, newNames)
+                in
+                    Table.Buffer(expanded),
+            flattened = List.Accumulate(
+                fieldNames, asTable, (asTable, fieldName) => ExpandRecord(asTable, fieldName)
+            )
+        in
+            Table.Buffer(flattened),
     SchemaUtils.Flatten = (listOfRecords as list, optional columnsToRemove as list) as table =>
         let
-            FlattenLists = (asTable as table, fieldNames as list) as table =>
-                Table.Buffer(
-                    Table.TransformColumns(
-                        asTable,
-                        List.Transform(fieldNames, (fieldName) => {fieldName, (row) => Text.Combine(row, ",")})
-                    )
-                ),
-            FlattenRecords = (asTable as table, fieldNames as list) as table =>
-                let
-                    ExpandRecord = (asTable as table, fieldName as text) as any =>
-                        let
-                            namesToExpand = List.Distinct(
-                                Record.FieldNames(Record.Combine(Table.Column(asTable, fieldName)))
-                            ),
-                            newNames = List.Transform(
-                                namesToExpand, (nameToExpand) => Text.Combine({fieldName, nameToExpand}, ".")
-                            ),
-                            expanded = Table.ExpandRecordColumn(asTable, fieldName, namesToExpand, newNames)
-                        in
-                            Table.Buffer(expanded),
-                    flattened = List.Accumulate(
-                        fieldNames, asTable, (asTable, fieldName) => ExpandRecord(asTable, fieldName)
-                    )
-                in
-                    Table.Buffer(flattened),
             flattenedSubTable =
                 if SchemaUtils.IsFlat(listOfRecords) then
                     let
@@ -98,10 +136,10 @@ let
                         ),
                         // Flatten lists
                         listFieldNames = SchemaUtils.FieldNamesOfType(listOfRecords, List.Type),
-                        withFlattenedLists = FlattenLists(reducedTable, listFieldNames),
+                        withFlattenedLists = SchemaUtils.FlattenLists(reducedTable, listFieldNames),
                         // Flatten records
                         recordFieldNames = SchemaUtils.FieldNamesOfType(listOfRecords, Record.Type),
-                        withFlattenedRecords = FlattenRecords(withFlattenedLists, recordFieldNames)
+                        withFlattenedRecords = SchemaUtils.FlattenRecords(withFlattenedLists, recordFieldNames)
                     in
                         @SchemaUtils.Flatten(Table.ToRecords(withFlattenedRecords))
         in
@@ -169,6 +207,8 @@ in
         GetSessionItemsResponse = SchemaUtils.GetSessionItemsResponse,
         FieldNamesOfType = SchemaUtils.FieldNamesOfType,
         IsFlat = SchemaUtils.IsFlat,
+        FlattenLists = SchemaUtils.FlattenLists,
+        FlattenRecords = SchemaUtils.FlattenRecords,
         Flatten = SchemaUtils.Flatten,
         GetResponseWithSchema = SchemaUtils.GetResponseWithSchema,
         ApplySchema = SchemaUtils.ApplySchema

--- a/SafeguardSessions/test/Unit/schema/TestFlatten.query.pq
+++ b/SafeguardSessions/test/Unit/schema/TestFlatten.query.pq
@@ -4,7 +4,119 @@ SchemaUtils = Extension.ImportModule("SchemaUtils.pqm");
 
 SchemaUtils.FieldNamesOfType = SchemaUtils[FieldNamesOfType];
 SchemaUtils.IsFlat = SchemaUtils[IsFlat];
+SchemaUtils.FlattenLists = SchemaUtils[FlattenLists];
+SchemaUtils.FlattenRecords = SchemaUtils[FlattenRecords];
 SchemaUtils.Flatten = SchemaUtils[Flatten];
+
+TestFlatteningLists = () =>
+    let
+        AssertResult = (description as text, t as table, fieldNames as list, expectedTable as table) =>
+            Fact(description, expectedTable, SchemaUtils.FlattenLists(t, fieldNames)),
+        fieldNames = {"list_field"},
+        cases = {
+            {
+                "List field is flattened correctly",
+                #table({"list_field"}, {{{"1", "2"}}, {{"3", "4"}}}),
+                fieldNames,
+                #table(type table [list_field = any], {{"1,2"}, {"3,4"}})
+            },
+            {
+                "List field with empty list is flattened correctly",
+                #table({"list_field"}, {{{}}, {{"3", "4"}}}),
+                fieldNames,
+                #table(type table [list_field = any], {{""}, {"3,4"}})
+            },
+            {
+                "List field with null value is flattened correctly",
+                #table({"list_field"}, {{{"1", "2"}}, {null}}),
+                fieldNames,
+                #table(type table [list_field = any], {{"1,2"}, {null}})
+            },
+            {
+                "Multiple list fields are flattened correctly",
+                #table({"list_field_1", "list_field_2"}, {{{"1", "2"}, {"4", "3"}}, {{"3", "4"}, {"2", "1"}}}),
+                {"list_field_1", "list_field_2"},
+                #table(type table [list_field_1 = any, list_field_2 = any], {{"1,2", "4,3"}, {"3,4", "2,1"}})
+            }
+        },
+        facts = ProvideDataForTest(cases, AssertResult)
+    in
+        facts;
+
+TestFlattenListsHandlesListWithNonTextValue = () =>
+    let
+        t = #table({"session_id", "list_field"}, {{"id1", {"1", "2"}}, {"id2", {"3", 4}}}),
+        fieldNames = {"list_field"},
+        withFlattenedLists = SchemaUtils.FlattenLists(t, fieldNames),
+        cellValue = try withFlattenedLists{[session_id = "id2"]}[list_field],
+        withErrorsReplaced = Table.ReplaceErrorValues(withFlattenedLists, {"list_field", "error_replaced"}),
+        facts = {
+            TestErrorIsRaised(
+                cellValue,
+                "List To Text Conversion Error",
+                "The list contains other types than text.",
+                [
+                    ManuallyHandled = true,
+                    Cause = "[""3"",4]",
+                    RequestUrl = null
+                ]
+            ),
+            Fact(
+                "The rest of the response is correct",
+                #table(type table [session_id = any, list_field = any], {{"id1", "1,2"}, {"id2", "error_replaced"}}),
+                withErrorsReplaced
+            )
+        }
+    in
+        facts;
+
+TestFlatteningRecords = () =>
+    let
+        AssertResult = (description as text, t as table, fieldNames as list, expectedTable as table) =>
+            Fact(description, expectedTable, SchemaUtils.FlattenRecords(t, fieldNames)),
+        cases = {
+            {
+                "Record field is flattened correctly",
+                #table({"record_field"}, {{[a = 1]}, {[b = 2]}}),
+                {"record_field"},
+                #table(type table [record_field.a = any, record_field.b = any], {{1, null}, {null, 2}})
+            },
+            {
+                "Record field with empty record is flattened correctly",
+                #table({"record_field"}, {{[]}, {[b = 2]}}),
+                {"record_field"},
+                #table(type table [record_field.b = any], {{null}, {2}})
+            },
+            {
+                "Record field with null record is flattened correctly",
+                #table({"record_field"}, {{[a = 1]}, {null}}),
+                {"record_field"},
+                #table(type table [record_field.a = any], {{1}, {null}})
+            },
+            {
+                "Record with complex structure is flattened correctly",
+                #table({"record_field"}, {{[a = 2, b = 10]}, {[]}, {[b = 2]}, {null}}),
+                {"record_field"},
+                #table(
+                    type table [record_field.a = any, record_field.b = any],
+                    {{2, 10}, {null, null}, {null, 2}, {null, null}}
+                )
+            },
+            {
+                "Multiple record fields are flattened correctly",
+                #table({"record_field_1", "record_field_2"}, {{[a = 1], [c = 3]}, {[b = 2], [d = 4]}}),
+                {"record_field_1", "record_field_2"},
+                #table(
+                    type table [
+                        record_field_1.a = any, record_field_1.b = any, record_field_2.c = any, record_field_2.d = any
+                    ],
+                    {{1, null, 3, null}, {null, 2, null, 4}}
+                )
+            }
+        },
+        facts = ProvideDataForTest(cases, AssertResult)
+    in
+        facts;
 
 TestGettingFieldNamesOfType = () =>
     let
@@ -177,6 +289,13 @@ TestFlattening = () =>
         facts;
 
 shared TestFlatten.UnitTest = [
-    facts = {TestGettingFieldNamesOfType(), TestFlatness(), TestFlattening()},
+    facts = {
+        TestGettingFieldNamesOfType(),
+        TestFlatness(),
+        TestFlatteningLists(),
+        TestFlattenListsHandlesListWithNonTextValue(),
+        TestFlatteningRecords(),
+        TestFlattening()
+    },
     report = Facts.Summarize(facts)
 ][report];

--- a/SafeguardSessions/test/assets/schema/GetDataAsset.pqm
+++ b/SafeguardSessions/test/assets/schema/GetDataAsset.pqm
@@ -4,13 +4,6 @@
             [
                 body = [
                     active = false,
-                    analytics = [
-                        interesting_events = {"ls", "sudo"},
-                        score = [aggregated = 21],
-                        scripted = false,
-                        similar_sessions = {},
-                        tags = {}
-                    ],
                     client = [ip = "10.10.0.39", name = "10.10.0.39", port = 2370],
                     creation_time = "2019-11-25T23:59:28.000Z",
                     duration = 0,
@@ -1222,8 +1215,6 @@
         {
             {
                 false,
-                "ls,sudo",
-                21,
                 null,
                 null,
                 null,
@@ -1231,11 +1222,13 @@
                 null,
                 null,
                 null,
-                false,
-                "",
                 null,
                 null,
-                "",
+                null,
+                null,
+                null,
+                null,
+                null,
                 "10.10.0.39",
                 "10.10.0.39",
                 "2370",


### PR DESCRIPTION
Scope: SafeguardSessions/modules/schema/SchemaUtils.pqm

FlattenLists and FlattendRecords utility functions did not properly handle null values. The functions have been fixed and outfactored to make them testable.