### PR TITLE
sps: Move ManuallyHandled initialization to ErrorBase

### DIFF
--- a/SafeguardSessions/modules/Types.pqm
+++ b/SafeguardSessions/modules/Types.pqm
@@ -103,12 +103,6 @@ let
             ]
         ),
         detail as [
-            ManuallyHandled = (
-                type logical meta [
-                    Documentation.FieldCaption = "Handled error",
-                    Documentation.FieldDescription = "Whether the error is handled manually in the code or it should propagate up to the user"
-                ]
-            ),
             Cause = (
                 type any meta [
                     Documentation.FieldCaption = "Cause of the error",
@@ -118,7 +112,13 @@ let
             RequestUrl = (type nullable text meta [
                 Documentation.FieldCaption = "Request url"
             ])
-        ]
+        ],
+        optional manuallyHandled as (
+            type logical meta [
+                Documentation.FieldCaption = "Handled error",
+                Documentation.FieldDescription = "Whether the error is handled manually in the code or it should propagate up to the user"
+            ]
+        )
     ) as table meta [
         Documentation.Name = "ErrorBase"
     ]

--- a/SafeguardSessions/modules/error/ErrorBase.pqm
+++ b/SafeguardSessions/modules/error/ErrorBase.pqm
@@ -1,7 +1,16 @@
 let
     ErrorBase.Type = Extension.ImportFunction("ErrorBaseType", "Types.pqm"),
-    ErrorBase.Implementation = (reason as text, message as text, detail as record) =>
-        error [Reason = reason, Message = message, Detail = detail],
+    ErrorBase.Implementation = (
+        reason as text, message as text, detail as record, optional manuallyHandled as logical
+    ) =>
+        let
+            detailRecord = detail & [ManuallyHandled = manuallyHandled ?? true]
+        in
+            error [
+                Reason = reason,
+                Message = message,
+                Detail = detailRecord
+            ],
     ErrorBase.Error = Value.ReplaceType(ErrorBase.Implementation, ErrorBase.Type)
 in
     ErrorBase.Error

--- a/SafeguardSessions/modules/error/QueryTransformErrors.pqm
+++ b/SafeguardSessions/modules/error/QueryTransformErrors.pqm
@@ -4,7 +4,8 @@ let
         ErrorBase(
             "Filter Field Without Value",
             "There is a field value missing from one or more of your filter fields.",
-            detail
+            detail,
+            false
         )
 in
     [

--- a/SafeguardSessions/modules/request/QueryParameterTransformer.pqm
+++ b/SafeguardSessions/modules/request/QueryParameterTransformer.pqm
@@ -29,7 +29,6 @@ let
                                 if current{0} <> null then
                                     FilterFieldWithoutValueError(
                                         [
-                                            ManuallyHandled = false,
                                             Cause = current{0},
                                             RequestUrl = null
                                         ]

--- a/SafeguardSessions/modules/request/ResponseHandler.pqm
+++ b/SafeguardSessions/modules/request/ResponseHandler.pqm
@@ -42,7 +42,6 @@ let
                 ]
             ),
             details = [
-                ManuallyHandled = true,
                 Cause = response,
                 RequestUrl = log[RequestUrl]
             ]

--- a/SafeguardSessions/modules/schema/SchemaUtils.pqm
+++ b/SafeguardSessions/modules/schema/SchemaUtils.pqm
@@ -25,7 +25,6 @@ let
                             ),
                             converted = SchemaTransformationErrors.ListToTextConversionError(
                                 [
-                                    ManuallyHandled = true,
                                     Cause = Text.FromBinary(Json.FromValue(log[Value])),
                                     RequestUrl = null
                                 ]

--- a/SafeguardSessions/test/Unit/TestResponseHandler.query.pq
+++ b/SafeguardSessions/test/Unit/TestResponseHandler.query.pq
@@ -77,6 +77,7 @@ TestGetDataFromResponse = () =>
                         Reason = "Not Parsable Response",
                         Message = "The source IP returned a response with missing fields.",
                         Detail = [
+                            ManuallyHandled = true,
                             Cause = fake_response,
                             MissingField = "",
                             RequestUrl = "dummy_url"
@@ -95,6 +96,7 @@ TestGetDataFromResponse = () =>
                         Reason = "Not Parsable Response",
                         Message = "The source IP returned a response with missing fields.",
                         Detail = [
+                            ManuallyHandled = true,
                             Cause = fake_response,
                             MissingField = "body/svc1/protocol",
                             RequestUrl = "dummy_url"

--- a/SafeguardSessions/test/Unit/TestSearch.query.pq
+++ b/SafeguardSessions/test/Unit/TestSearch.query.pq
@@ -140,6 +140,7 @@ TestGetSessionsCountRaisesError = () =>
         expectedReason = "Not Parsable Response",
         expectedMessage = "The source IP returned a response with missing fields.",
         expectedDetail = [
+            ManuallyHandled = true,
             Cause = [invalid = "response"],
             MissingField = "count",
             RequestUrl = requestUrl
@@ -195,6 +196,7 @@ TestOpenSnapshotRaisesError = () =>
                 "Not Parsable Response",
                 "The source IP returned a response with missing fields.",
                 [
+                    ManuallyHandled = true,
                     Cause = [invalid = "response"],
                     MissingField = "body.snapshot"
                 ]


### PR DESCRIPTION
ManuallyHandled initialization has been moved to ErrorBase with a default value of true. Setting ManuallyHandled by default to true makes it unnecessary to provide its value in the detail parameter while using most of the custom errors.