### PR TITLE
sps: Extend ApplySchema with error handling

### DIFF
--- a/SafeguardSessions/README.md
+++ b/SafeguardSessions/README.md
@@ -96,6 +96,12 @@ This happens if multiple users from different computers or using different progr
 
 This error indicates issues with the SPS appliance. Try the suggestions written in the [Troubleshooting](#troubleshooting) section.
 
+**H) An error happened when applying schema.**
+
+In order to display the session records from SPS in a user-friendly way in Power BI, schema must be mapped to the session records. This error means that at least one session occurred in the SPS response that the schema application could not handle correctly and caused an unexpected error.
+Reproduce the error with trace logging enabled, and create a technical case, as described in the [Troubleshooting](#troubleshooting) section.
+Attach the mashup trace logs to the issue.
+
 ## Troubleshooting
 
 If an error occurs during the data fetching process, you can check the **Info** table to see a descriptive message about the error type. In this case, the **Sessions** table will contain the exact error record that you can inspect if you go to **Home > Transform data** and select the **Sessions** table.

--- a/SafeguardSessions/modules/Search.pqm
+++ b/SafeguardSessions/modules/Search.pqm
@@ -95,7 +95,7 @@ let
                     Record.Field(mocks[Schema], "Sessions")
                 else
                     Schema.GetSchema("Sessions"),
-            page = SchemaUtils.ApplySchema(response, schema) meta [NextLink = nextLink]
+            page = SchemaUtils.ApplySchema(response, schema, mocks) meta [NextLink = nextLink]
         in
             page,
     Search.GenerateByPage = (getNextPage as function) as table =>

--- a/SafeguardSessions/modules/error/SchemaTransformationErrors.pqm
+++ b/SafeguardSessions/modules/error/SchemaTransformationErrors.pqm
@@ -1,8 +1,15 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
     SchemaTransformationErrors.ListToTextConversionError = (detail as record) =>
-        ErrorBase("List To Text Conversion Error", "The list contains other types than text.", detail)
+        ErrorBase("List To Text Conversion Error", "The list contains other types than text.", detail),
+    SchemaTransformationErrors.SchemaApplyError = (detail as record) =>
+        ErrorBase(
+            "Schema Apply Error",
+            "An error happened when applying schema.",
+            detail
+        )
 in
     [
-        ListToTextConversionError = SchemaTransformationErrors.ListToTextConversionError
+        ListToTextConversionError = SchemaTransformationErrors.ListToTextConversionError,
+        SchemaApplyError = SchemaTransformationErrors.SchemaApplyError
     ]

--- a/SafeguardSessions/modules/schema/SchemaUtils.pqm
+++ b/SafeguardSessions/modules/schema/SchemaUtils.pqm
@@ -1,12 +1,33 @@
 let
+    IsMocked = Extension.ImportFunction("IsMocked", "Utils.pqm"),
     PaddedTable.FromRecords = Extension.ImportFunction("PaddedTable.FromRecords", "Utils.pqm"),
     SchemaTransformationErrors.ListToTextConversionError = Extension.ImportFunction(
         "ListToTextConversionError", "SchemaTransformationErrors.pqm"
+    ),
+    SchemaTransformationErrors.SchemaApplyError = Extension.ImportFunction(
+        "SchemaApplyError", "SchemaTransformationErrors.pqm"
     ),
     Logger.ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm"),
     SchemaUtils.NameColumn = "Name",
     SchemaUtils.TypeColumn = "Type",
     SchemaUtils.Header = {SchemaUtils.NameColumn, SchemaUtils.TypeColumn},
+    SchemaUtils.HandleUnexpectedSchemaApplyError = (input as record, response as record) =>
+        if input[HasError] = true then
+            let
+                log = Logger.ErrorLog("An error happened when applying schema", [
+                    Error = input[Error]
+                ]),
+                withResponse = log & [Response = response],
+                converted = SchemaTransformationErrors.SchemaApplyError(
+                    [
+                        Cause = withResponse[Response],
+                        RequestUrl = Value.Metadata(response)[RequestUrl]
+                    ]
+                )
+            in
+                converted
+        else
+            input[Value],
     SchemaUtils.CreateSchema = (fields as list) => #table(SchemaUtils.Header, fields),
     SchemaUtils.ConvertListToText = (l as nullable list, fieldName as text) as nullable text =>
         let
@@ -184,12 +205,17 @@ let
             withType = Value.ReplaceType(enforcedTypes, SchemaToTableType(schema))
         in
             withType,
-    SchemaUtils.ApplySchema = (response as record, schema as table) =>
+    SchemaUtils.ApplySchema = (response as record, schema as table, optional mocks as nullable record) =>
         let
             transformedResponse = SchemaUtils.GetSessionItemsResponse(response),
             flattenedResponse = SchemaUtils.Flatten(transformedResponse, {"vault"}),
-            withSchema = SchemaUtils.GetResponseWithSchema(flattenedResponse, schema),
-            withMeta = Value.ReplaceMetadata(withSchema, Value.Metadata(response))
+            withSchema =
+                if IsMocked(mocks, "ApplySchema") then
+                    mocks[ApplySchema]
+                else
+                    SchemaUtils.GetResponseWithSchema(flattenedResponse, schema),
+            processedResponse = SchemaUtils.HandleUnexpectedSchemaApplyError(try (withSchema), response),
+            withMeta = Value.ReplaceMetadata(processedResponse, Value.Metadata(response))
         in
             withMeta
 in

--- a/SafeguardSessions/test/Integration/TestGetData.query.pq
+++ b/SafeguardSessions/test/Integration/TestGetData.query.pq
@@ -226,7 +226,11 @@ TestGetDataHandlesAuthenticationError = () =>
             Message.Parameters = null
         ],
         expectedInfo = FetchInfo(
-            "Error", "The username or password you have specified is invalid.", null, 0, true,
+            "Error",
+            "The username or password you have specified is invalid.",
+            null,
+            0,
+            true,
             "https://dummy_url/api/authentication"
         ),
         response = GetData(
@@ -239,6 +243,36 @@ TestGetDataHandlesAuthenticationError = () =>
         )
     in
         TestResultsContentWithoutStartTime(response, expectedData, expectedInfo);
+
+TestGetDataWithActualData = () =>
+    let
+        fakeResponses = [
+            #"https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id" = TestSafeguardSessions.ActualResponse
+        ],
+        expectedData = TestSafeguardSessions.ExpectedDataForActualResponse,
+        expectedInfo = FetchInfo(
+            "Success",
+            "Data fetch succeeded.",
+            null,
+            25,
+            false,
+            "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id"
+        ),
+        response = GetData(
+            TestSafeguardSessions.URL,
+            TestSafeguardSessions.AuthenticationCredentials,
+            [],
+            [
+                AuthResponse = TestSafeguardSessions.SuccessfulAuthenticationResponse,
+                GetSessionsCountResponse = TestSafeguardSession.GetExpectedCountResponse(25),
+                OpenSnapshotResponse = TestSafeguardSession.SuccessfulOpenSnapshotResponse,
+                GetPageResponseMap = fakeResponses
+            ]
+        )
+    in
+        TestResultsContentWithoutStartTime(
+            response, TestSafeguardSessions.ExpectedDataForActualResponse, expectedInfo
+        );
 
 TestGetDataHandlesBadRequest = () =>
     let
@@ -395,18 +429,33 @@ TestGetDataReturnWithAnUnexpectedErrorBecauseSomethingUnexpectedHappendDuringDat
     in
         Fact("Check error is raised", expectedResponse, response);
 
-TestGetDataWithActualData = () =>
+TestGetDataHandlesSchemaApplyError = () =>
     let
         fakeResponses = [
             #"https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id" = TestSafeguardSessions.ActualResponse
         ],
-        expectedData = TestSafeguardSessions.ExpectedDataForActualResponse,
+        unexpectedErrorRecord = [
+            Reason = "Wrong variable",
+            Message = "Variable type mismatch error",
+            Detail = "The variable badVariable is of the type text, but it should be of the type list"
+        ],
+        expectedData = [
+            Reason = "Schema Apply Error",
+            Message = "An error happened when applying schema.",
+            Detail = [
+                Cause = TestSafeguardSessions.ActualResponseData,
+                RequestUrl = "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id",
+                ManuallyHandled = true
+            ],
+            Message.Format = null,
+            Message.Parameters = null
+        ],
         expectedInfo = FetchInfo(
-            "Success",
-            "Data fetch succeeded.",
+            "Error",
+            "An error happened when applying schema.",
             null,
-            25,
-            false,
+            0,
+            true,
             "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id"
         ),
         response = GetData(
@@ -417,26 +466,26 @@ TestGetDataWithActualData = () =>
                 AuthResponse = TestSafeguardSessions.SuccessfulAuthenticationResponse,
                 GetSessionsCountResponse = TestSafeguardSession.GetExpectedCountResponse(25),
                 OpenSnapshotResponse = TestSafeguardSession.SuccessfulOpenSnapshotResponse,
-                GetPageResponseMap = fakeResponses
+                GetPageResponseMap = fakeResponses,
+                ApplySchema = error unexpectedErrorRecord
             ]
         )
     in
-        TestResultsContentWithoutStartTime(
-            response, TestSafeguardSessions.ExpectedDataForActualResponse, expectedInfo
-        );
+        TestResultsContentWithoutStartTime(response, expectedData, expectedInfo);
 
 shared TestSafeguardSessions.IntegrationTest = [
     facts = {
         TestEmptyResponseIsHandled(),
         TestGetDataWithoutError(),
         TestGetDataWithQueryInputs(),
+        TestGetDataWithActualData(),
         TestGetDataHandlesAuthenticationError(),
         TestGetDataHandlesBadRequest(),
         TestGetDataHandlesErrorWithoutRequestUrlInErrorDetailDuringAuth(),
         TestGetDataHandlesErrorWithoutRequestUrlInErrorDetailDuringDataFetch(),
         TestGetDataReturnWithAnUnexpectedErrorBecauseSomethingUnexpectedHappendDuringAuthenication(),
         TestGetDataReturnWithAnUnexpectedErrorBecauseSomethingUnexpectedHappendDuringDataFetch(),
-        TestGetDataWithActualData()
+        TestGetDataHandlesSchemaApplyError()
     },
     report = Facts.Summarize(facts)
 ][report];


### PR DESCRIPTION
Scope: SafeguardSessions/modules/schema/SchemaUtils.pqm

Error handling has been introduced in the SchemaUtils.ApplySchema method. This was necessary because if an error occurs here, only the error itself is logged, not the SPS response data that caused it, but that's an important element in finding out what caused the error.

During error handling, the unexpected error is logged, and then a new manually handled error is raised called SchemaApplyError, which contains the response that caused the error. The new error generated here is then handled in Utils.BuildSPSResult, where the response is logged.

References: azure #419489