### PR TITLE
sps: Refine version check

### DIFF
--- a/SafeguardSessions/modules/version/Version.pqm
+++ b/SafeguardSessions/modules/version/Version.pqm
@@ -7,6 +7,7 @@ let
     ResponseHandler.GetDataFromResponse = Extension.ImportFunction("GetDataFromResponse", "ResponseHandler.pqm"),
     ResponseHandler.ValidateByStatusCode = Extension.ImportFunction("ValidateByStatusCode", "ResponseHandler.pqm"),
     UrlBuilder.GenerateUrl = Extension.ImportFunction("GenerateUrl", "UrlBuilder.pqm"),
+    Version.Separator = ".",
     Version.GetVersion = (spsUrl as text, sessionId as text, optional mocks as nullable record) as text =>
         let
             infoUrl = UrlBuilder.GenerateUrl(spsUrl, InfoEndpoint),
@@ -26,7 +27,12 @@ let
     Version.CheckVersion = (version as text, supportedVersions as list) as logical =>
         let
             IsVersionAccepted = (version, supportedVersion) =>
-                Text.StartsWith(version, supportedVersion, Comparer.OrdinalIgnoreCase),
+                let
+                    versionParts = Text.Split(version, Version.Separator),
+                    supportedVersionParts = Text.Split(supportedVersion, Version.Separator),
+                    commonLength = List.Min({List.Count(versionParts), List.Count(supportedVersionParts)})
+                in
+                    List.FirstN(versionParts, commonLength) = List.FirstN(supportedVersionParts, commonLength),
             versionAccepted = List.Contains(
                 supportedVersions, version, (supportedVersion) => IsVersionAccepted(version, supportedVersion)
             )

--- a/SafeguardSessions/test/Unit/version/TestCheckVersion.query.pq
+++ b/SafeguardSessions/test/Unit/version/TestCheckVersion.query.pq
@@ -14,14 +14,8 @@ AssertVersionCheck = (description as text, version as text, supportedVersions as
 
 TestCheckVersion = () =>
     let
-        dummySupportedVersions = {"custom", "1.1", "2.0", "2.1"},
+        dummySupportedVersions = {"1.1", "2.0", "2.1"},
         cases = {
-            {
-                "Custom SPS version for testing is supported by the custom connector",
-                "custom_version_for_testing",
-                dummySupportedVersions,
-                true
-            },
             {
                 "Latest supported SPS version is supported by the custom connector",
                 "2.1",
@@ -45,6 +39,12 @@ TestCheckVersion = () =>
             {
                 "Future SPS version with breaking change is not supported by the custom connector",
                 "2.2",
+                dummySupportedVersions,
+                false
+            },
+            {
+                "Far-future SPS version with breaking change is not supported by the custom connector",
+                "2.10",
                 dummySupportedVersions,
                 false
             },


### PR DESCRIPTION
Scope: SafeguardSessions/modules/version/Version.pqm

The previously implemented version check using Text.StartsWith accepted future relases in some cases, e.g. 7.30 if 7.3 was in the supported versions list.

A possible solution was to explicitly write 7.3. in the supported versions list or append a "." in the version check function. Instead of using this method, a more sophisticated solution has been implemented.

The versions to be compared are split along the "." character, the common length is defined, and first common-length number of elements are compared.