### PR TITLE
sps: Add error codes

### DIFF
--- a/SafeguardSessions/CONTRIBUTION.md
+++ b/SafeguardSessions/CONTRIBUTION.md
@@ -65,6 +65,13 @@ When writing **commit messages**, consider the following:
     - If it both has a work item in Azure DevOps and a GitHub issue: `References: azure #<azure-id>, #<github-id>`
 - For examples, view the [Commit history of the main branch]
 
+## Error codes
+
+When introducing a new error code, please consider the following:
+
+- The error codes from the HTTP Requests should have a zero at the end if there is already an error ending with a zero then the next error code falling in the same HTTP Request category should be incremented by one.
+- The error code for errors originating from the connector should be incremented by one.
+
 ## How to contribute to the project
 
 1. Fork the [GitHub project]

--- a/SafeguardSessions/README.md
+++ b/SafeguardSessions/README.md
@@ -78,37 +78,37 @@ https://github.com/OneIdentity/SafeguardPowerBI/releases
 
 I see "Error" in the **Status** column of the **Info** table, and the **Message** column contains the following:
 
-**A)** The source IP returned a response with missing fields.
+**A)** Error 10003: The source IP returned a response with missing fields.
 
 A response returned by SPS does not contain a field that the Power BI Connector requires for processing data.
 Reproduce the error with trace logging enabled, and create a technical case, as described in the [Troubleshooting] section.
 Attach the mashup trace logs to the issue.
 
-**B)** The source IP interpreted a malformed request.
+**B)** Error 4000: The source IP interpreted a malformed request.
 
 Your filter might be invalid. Make sure you specify your filter parameters correctly. For more information on the available search fields, see **List of available search queries** in the **One Identity Safeguard for Privileged Sessions Administration Guide** on the [Technical documents for One Identity Safeguard for Priviledged Sessions] page.
 
-**C)** The username or password you have specified is invalid.
+**C)** Error 4010: The username or password you have specified is invalid.
 
 Make sure you use a local user to access SPS with a valid username and password. One Identity recommends creating a dedicated local user for the purpose of importing data from SPS into Power BI.
 
-**D)** You are not authorized to access the specified resource.
+**D)** Error 4030: You are not authorized to access the specified resource.
 
 In order to access audit data, the user you use to access SPS must have search access rights.
 
-**E)** The requested resource is not found.
+**E)** Error 4040: The requested resource is not found.
 
 In order to fetch audit data from SPS, the Power BI Connector relies on the advanced search method, which uses database snapshots to ensure data consistency throughout data fetching. If for some reason, the database snapshot disappears, this error can occur. To resolve the issue, try initiating the data fetching again.
 
-**F)** Snapshot quota exceeded.
+**F)** Error 4290: Snapshot quota exceeded.
 
 This happens if multiple users from different computers or using different programs want to use advanced search relying on database snapshots at the same time. In this case, try initiating the data fetching process at least 5 minutes later so that an existing snapshot expires in the system, and a new one can be opened.
 
-**G)** The source IP responded with a server error.
+**G)** Error 5000: The source IP responded with a server error.
 
 This error indicates issues with the SPS appliance. Try the suggestions written in the [Troubleshooting] section.
 
-**H)** An error happened when applying schema.
+**H)** Error 10005: An error happened when applying schema.
 
 In order to display the session records from SPS in a user-friendly way in Power BI, schema must be mapped to the session records. This error means that at least one session occurred in the SPS response that the schema application could not handle correctly and caused an unexpected error.
 Reproduce the error with trace logging enabled, and create a technical case, as described in the [Troubleshooting] section.

--- a/SafeguardSessions/SafeguardSessions.pq
+++ b/SafeguardSessions/SafeguardSessions.pq
@@ -147,7 +147,7 @@ shared FetchData = (spsUrl as text, queryParams as record, sessionId as text, op
     in
         sessionsWithCountMetadata;
 
-HandleIfThereIsAnError = (input as record) =>
+shared HandleIfThereIsAnError = (input as record) =>
     if input[HasError] = true then
         if input[Error][Detail] is record and Record.HasFields(input[Error][Detail], "ManuallyHandled") then
             if input[Error][Detail][ManuallyHandled] = true then
@@ -156,7 +156,10 @@ HandleIfThereIsAnError = (input as record) =>
                 error input[Error]
         else
             let
-                logNotExpectedError = Logger.ErrorLog("An unexpected error happend during execution", input[Error])
+                transformedError = TransformUnexpectedError(input[Error]),
+                logNotExpectedError = Logger.ErrorLog(
+                    "An unexpected error happend during execution", transformedError
+                )
             in
                 error logNotExpectedError
     else
@@ -255,3 +258,5 @@ UrlBuilder.GetDefaultQuery = UrlBuilder[GetDefaultQuery];
 Logger.ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm");
 
 AuthEndpoint = Extension.ImportFunction("AuthEndpoint", "Constants.pqm");
+
+TransformUnexpectedError = Extension.ImportFunction("TransformUnexpectedError", "UnexpectedErrorWrapper.pqm");

--- a/SafeguardSessions/SafeguardSessions.proj
+++ b/SafeguardSessions/SafeguardSessions.proj
@@ -25,9 +25,11 @@
     <MezContent Include="$(VersionPath)Version.pqm" />
     <MezContent Include="$(VersionPath)SupportedVersions.pqm" />
     <MezContent Include="$(ErrorPath)ErrorBase.pqm" />
+    <MezContent Include="$(ErrorPath)ErrorCodes.pqm" />
     <MezContent Include="$(ErrorPath)SchemaTransformationErrors.pqm" />
     <MezContent Include="$(ErrorPath)QueryTransformErrors.pqm" />
     <MezContent Include="$(ErrorPath)RequestErrors.pqm" />
+    <MezContent Include="$(ErrorPath)UnexpectedErrorWrapper.pqm" />
     <MezContent Include="$(ErrorPath)VersionErrors.pqm" />
     <MezContent Include="$(RequestPath)UrlBuilder.pqm" />
     <MezContent Include="$(RequestPath)QueryParameterTransformer.pqm" />

--- a/SafeguardSessions/modules/Types.pqm
+++ b/SafeguardSessions/modules/Types.pqm
@@ -97,6 +97,12 @@ let
         for the filter field. For the From and To search fields, if only one of them is specified, the search in the other direction remains open."
     ],
     CustomErrors.ErrorBaseType = type function (
+        errorCode as (
+            type number meta [
+                Documentation.FieldCaption = "Error code",
+                Documentation.FieldDescription = "The raised error's code"
+            ]
+        ),
         reason as (
             type text meta [
                 Documentation.FieldCaption = "Error reason",

--- a/SafeguardSessions/modules/error/ErrorBase.pqm
+++ b/SafeguardSessions/modules/error/ErrorBase.pqm
@@ -1,10 +1,16 @@
 let
     ErrorBase.Type = Extension.ImportFunction("ErrorBaseType", "Types.pqm"),
     ErrorBase.Implementation = (
-        reason as text, message as text, detail as record, optional manuallyHandled as logical
+        errorCode as number, reason as text, message as text, detail as record, optional manuallyHandled as logical
     ) =>
         let
-            detailRecord = detail & [ManuallyHandled = manuallyHandled ?? true]
+            message = Text.Format(
+                "Error #[ErrorCode]: #[Message]", [
+                    ErrorCode = Number.ToText(errorCode),
+                    Message = message
+                ]
+            ),
+            detailRecord = detail & [ManuallyHandled = manuallyHandled ?? true] & [ErrorCode = errorCode]
         in
             error [
                 Reason = reason,

--- a/SafeguardSessions/modules/error/ErrorCodes.pqm
+++ b/SafeguardSessions/modules/error/ErrorCodes.pqm
@@ -1,0 +1,22 @@
+let
+    ErrorCodes.ExtendedHTTPCodes = [
+        BadRequest = 4000,
+        AuthenticationError = 4010,
+        AuthorizationError = 4030,
+        NotFound = 4040,
+        SnapshotQuotaError = 4290,
+        ServerError = 5000
+    ],
+    ErrorCodes.CustomCodes = [
+        FilterFieldWithoutValue = 10000,
+        NotSupportedVersion = 10001,
+        NotParsableResponse = 10002,
+        ListToTextConversionError = 10003,
+        SchemaApplyError = 10004,
+        Unexpected = 99999
+    ]
+in
+    [
+        ExtendedHTTPCodes = ErrorCodes.ExtendedHTTPCodes,
+        CustomCodes = ErrorCodes.CustomCodes
+    ]

--- a/SafeguardSessions/modules/error/QueryTransformErrors.pqm
+++ b/SafeguardSessions/modules/error/QueryTransformErrors.pqm
@@ -1,7 +1,9 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
+    ErrorCodes.CustomCodes = Extension.ImportFunction("CustomCodes", "ErrorCodes.pqm"),
     QueryTransformErrors.FilterFieldWithoutValue = (detail as record) =>
         ErrorBase(
+            ErrorCodes.CustomCodes[FilterFieldWithoutValue],
             "Filter Field Without Value",
             "There is a field value missing from one or more of your filter fields.",
             detail,

--- a/SafeguardSessions/modules/error/RequestErrors.pqm
+++ b/SafeguardSessions/modules/error/RequestErrors.pqm
@@ -1,24 +1,52 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
     ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm"),
+    ErrorCodes.ExtendedHTTPCodes = Extension.ImportFunction("ExtendedHTTPCodes", "ErrorCodes.pqm"),
+    ErrorCodes.CustomCodes = Extension.ImportFunction("CustomCodes", "ErrorCodes.pqm"),
     RequestErrors.NotParsableResponse = (detail as anynonnull) =>
-        ErrorBase("Not Parsable Response", "The source IP returned a response with missing fields.", detail),
+        ErrorBase(
+            ErrorCodes.CustomCodes[NotParsableResponse],
+            "Not Parsable Response",
+            "The source IP returned a response with missing fields.",
+            detail
+        ),
     RequestErrors.BadRequest = (detail as record) =>
         ErrorBase(
+            ErrorCodes.ExtendedHTTPCodes[BadRequest],
             "Bad Request",
             "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
             detail
         ),
     RequestErrors.AuthenticationError = (detail as record) =>
-        ErrorBase("Authentication Error", "The username or password you have specified is invalid.", detail),
+        ErrorBase(
+            ErrorCodes.ExtendedHTTPCodes[AuthenticationError],
+            "Authentication Error",
+            "The username or password you have specified is invalid.",
+            detail
+        ),
     RequestErrors.AuthorizationError = (detail as record) =>
-        ErrorBase("Authorization Error", "You are not authorized to access the specified resource.", detail),
+        ErrorBase(
+            ErrorCodes.ExtendedHTTPCodes[AuthorizationError],
+            "Authorization Error",
+            "You are not authorized to access the specified resource.",
+            detail
+        ),
     RequestErrors.NotFound = (detail as record) =>
-        ErrorBase("Not Found", "The requested resource is not found.", detail),
+        ErrorBase(
+            ErrorCodes.ExtendedHTTPCodes[NotFound], "Not Found", "The requested resource is not found.", detail
+        ),
     RequestErrors.SnapshotQuotaError = (detail as record) =>
-        ErrorBase("Snapshot Quota Error", "Snapshot quota exceeded.", detail),
+        ErrorBase(
+            ErrorCodes.ExtendedHTTPCodes[SnapshotQuotaError], "Snapshot Quota Error", "Snapshot quota exceeded.",
+            detail
+        ),
     RequestErrors.ServerError = (detail as record) =>
-        ErrorBase("Server Error", "The source IP responded with a server error.", detail),
+        ErrorBase(
+            ErrorCodes.ExtendedHTTPCodes[ServerError],
+            "Server Error",
+            "The source IP responded with a server error.",
+            detail
+        ),
     RequestErrors.ErrorMap = [
         400 = RequestErrors.BadRequest,
         401 = RequestErrors.AuthenticationError,

--- a/SafeguardSessions/modules/error/SchemaTransformationErrors.pqm
+++ b/SafeguardSessions/modules/error/SchemaTransformationErrors.pqm
@@ -1,9 +1,16 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
+    ErrorCodes.CustomCodes = Extension.ImportFunction("CustomCodes", "ErrorCodes.pqm"),
     SchemaTransformationErrors.ListToTextConversionError = (detail as record) =>
-        ErrorBase("List To Text Conversion Error", "The list contains other types than text.", detail),
+        ErrorBase(
+            ErrorCodes.CustomCodes[ListToTextConversionError],
+            "List To Text Conversion Error",
+            "The list contains other types than text.",
+            detail
+        ),
     SchemaTransformationErrors.SchemaApplyError = (detail as record) =>
         ErrorBase(
+            ErrorCodes.CustomCodes[SchemaApplyError],
             "Schema Apply Error",
             "An error happened when applying schema.",
             detail

--- a/SafeguardSessions/modules/error/UnexpectedErrorWrapper.pqm
+++ b/SafeguardSessions/modules/error/UnexpectedErrorWrapper.pqm
@@ -1,0 +1,19 @@
+let
+    ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
+    ErrorCodes.CustomCodes = Extension.ImportFunction("CustomCodes", "ErrorCodes.pqm"),
+    UnexpectedErrorWarper.TransformUnexpectedError = (handledError as record) =>
+        let
+            transformedError = ErrorBase(
+                ErrorCodes.CustomCodes[Unexpected],
+                handledError[Reason],
+                handledError[Message],
+                [
+                    originalDetails = handledError[Detail]
+                ],
+                false
+            ),
+            newHandledError = try transformedError
+        in
+            newHandledError[Error]
+in
+    [TransformUnexpectedError = UnexpectedErrorWarper.TransformUnexpectedError]

--- a/SafeguardSessions/modules/error/VersionErrors.pqm
+++ b/SafeguardSessions/modules/error/VersionErrors.pqm
@@ -1,8 +1,10 @@
 let
     ErrorBase = Extension.ImportModule("ErrorBase.pqm"),
     SupportedVersions.Versions = Extension.ImportFunction("Versions", "SupportedVersions.pqm"),
+    ErrorCodes.CustomCodes = Extension.ImportFunction("CustomCodes", "ErrorCodes.pqm"),
     VersionErrors.NotSupportedVersion = (version as text) =>
         ErrorBase(
+            ErrorCodes.CustomCodes[NotSupportedVersion],
             "Not Supported Version",
             Text.Format(
                 "Your version of the connector (#[ConnectorVersion]) is not compatible with your SPS version (#[SPSVersion]). For a connector version that is compatible with your SPS version, visit the official release page of the connector: https://github.com/OneIdentity/SafeguardPowerBI/releases",

--- a/SafeguardSessions/test/Integration/TestAuthentication.query.pq
+++ b/SafeguardSessions/test/Integration/TestAuthentication.query.pq
@@ -69,7 +69,9 @@ TestAuthenticateIsSuccessful = () =>
 
 TestAuthenticateRaisesError = () =>
     let
-        AssertErrorisRaised = (statusCode as number, expectedReason as text, expectedMessage as text) =>
+        AssertErrorisRaised = (
+            errorCode as number, statusCode as number, expectedReason as text, expectedMessage as text
+        ) =>
             let
                 fakeAuthResponse = FakeRawResponse([#"error" = "reason"], [
                     Response.Status = statusCode
@@ -88,15 +90,26 @@ TestAuthenticateRaisesError = () =>
                     [
                         ManuallyHandled = true,
                         Cause = [#"error" = "reason"],
-                        RequestUrl = "http://dummy_url/api/authentication"
+                        RequestUrl = "http://dummy_url/api/authentication",
+                        ErrorCode = errorCode
                     ]
                 )
             in
                 facts,
         cases = {
-            {401, "Authentication Error", "The username or password you have specified is invalid."},
-            {403, "Authorization Error", "You are not authorized to access the specified resource."},
-            {500, "Server Error", "The source IP responded with a server error."}
+            {
+                4010,
+                401,
+                "Authentication Error",
+                "Error 4010: The username or password you have specified is invalid."
+            },
+            {
+                4030,
+                403,
+                "Authorization Error",
+                "Error 4030: You are not authorized to access the specified resource."
+            },
+            {5000, 500, "Server Error", "Error 5000: The source IP responded with a server error."}
         },
         facts = ProvideDataForTest(cases, AssertErrorisRaised)
     in

--- a/SafeguardSessions/test/Integration/TestFetchData.query.pq
+++ b/SafeguardSessions/test/Integration/TestFetchData.query.pq
@@ -251,7 +251,9 @@ TestFetchDataWithInvalidTypeForField = () =>
 
 TestFetchDataRaisesErrorWhenAdvancedSearchInitialResponseFails = () =>
     let
-        AssertErrorIsRaised = (statusCode as number, expectedReason as text, expectedMessage as text) =>
+        AssertErrorIsRaised = (
+            statusCode as number, expectedReason as text, expectedMessage as text, expectedErrorCode as number
+        ) =>
             let
                 fakeResponses = [
                     #"http://dummy_url/api/audit/sessions?snapshot=dummy_snapshot_id" = FakeRawResponse(
@@ -277,17 +279,34 @@ TestFetchDataRaisesErrorWhenAdvancedSearchInitialResponseFails = () =>
                     [
                         ManuallyHandled = true,
                         Cause = [#"error" = "reason"],
-                        RequestUrl = "http://dummy_url/api/audit/sessions?snapshot=dummy_snapshot_id"
+                        RequestUrl = "http://dummy_url/api/audit/sessions?snapshot=dummy_snapshot_id",
+                        ErrorCode = expectedErrorCode
                     ]
                 )
             in
                 facts,
         cases = {
-            {400, "Bad Request", "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid."},
-            {401, "Authentication Error", "The username or password you have specified is invalid."},
-            {403, "Authorization Error", "You are not authorized to access the specified resource."},
-            {404, "Not Found", "The requested resource is not found."},
-            {500, "Server Error", "The source IP responded with a server error."}
+            {
+                400,
+                "Bad Request",
+                "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                4000
+            },
+            {
+                401,
+                "Authentication Error",
+                "Error 4010: The username or password you have specified is invalid.",
+                4010
+            },
+            {
+                403,
+                "Authorization Error",
+                "Error 4030: You are not authorized to access the specified resource.",
+                4030
+            },
+            {404, "Not Found", "Error 4040: The requested resource is not found.", 4040},
+            {429, "Snapshot Quota Error", "Error 4290: Snapshot quota exceeded.", 4290},
+            {500, "Server Error", "Error 5000: The source IP responded with a server error.", 5000}
         },
         facts = ProvideDataForTest(cases, AssertErrorIsRaised)
     in
@@ -295,7 +314,9 @@ TestFetchDataRaisesErrorWhenAdvancedSearchInitialResponseFails = () =>
 
 TestFetchDataRaisesErrorWhenAdvancedSearchSuccessiveResponseFails = () =>
     let
-        AssertErrorIsRaised = (statusCode as number, expectedReason as text, expectedMessage as text) =>
+        AssertErrorIsRaised = (
+            statusCode as number, expectedReason as text, expectedMessage as text, expectedErrorCode as number
+        ) =>
             let
                 fakeResponses = [
                     #"http://dummy_url/api/audit/sessions?snapshot=dummy_snapshot_id" = TestSafeguardSessions.Response.First,
@@ -322,17 +343,34 @@ TestFetchDataRaisesErrorWhenAdvancedSearchSuccessiveResponseFails = () =>
                     [
                         ManuallyHandled = true,
                         Cause = [#"error" = "reason"],
-                        RequestUrl = "http://dummy_url/dummy_url_next"
+                        RequestUrl = "http://dummy_url/dummy_url_next",
+                        ErrorCode = expectedErrorCode
                     ]
                 )
             in
                 facts,
         cases = {
-            {400, "Bad Request", "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid."},
-            {401, "Authentication Error", "The username or password you have specified is invalid."},
-            {403, "Authorization Error", "You are not authorized to access the specified resource."},
-            {404, "Not Found", "The requested resource is not found."},
-            {500, "Server Error", "The source IP responded with a server error."}
+            {
+                400,
+                "Bad Request",
+                "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                4000
+            },
+            {
+                401,
+                "Authentication Error",
+                "Error 4010: The username or password you have specified is invalid.",
+                4010
+            },
+            {
+                403,
+                "Authorization Error",
+                "Error 4030: You are not authorized to access the specified resource.",
+                4030
+            },
+            {404, "Not Found", "Error 4040: The requested resource is not found.", 4040},
+            {429, "Snapshot Quota Error", "Error 4290: Snapshot quota exceeded.", 4290},
+            {500, "Server Error", "Error 5000: The source IP responded with a server error.", 5000}
         },
         facts = ProvideDataForTest(cases, AssertErrorIsRaised)
     in
@@ -340,7 +378,9 @@ TestFetchDataRaisesErrorWhenAdvancedSearchSuccessiveResponseFails = () =>
 
 TestFetchDataRaisesErrorWhenCountRequestFails = () =>
     let
-        AssertErrorIsRaised = (statusCode as number, expectedReason as text, expectedMessage as text) =>
+        AssertErrorIsRaised = (
+            statusCode as number, expectedReason as text, expectedMessage as text, expectedErrorCode as number
+        ) =>
             let
                 fakeCountResponse = FakeRawResponse([#"error" = "reason"], [
                     Response.Status = statusCode
@@ -360,17 +400,34 @@ TestFetchDataRaisesErrorWhenCountRequestFails = () =>
                     [
                         ManuallyHandled = true,
                         Cause = [#"error" = "reason"],
-                        RequestUrl = "http://dummy_url/api/audit/sessions/_count"
+                        RequestUrl = "http://dummy_url/api/audit/sessions/_count",
+                        ErrorCode = expectedErrorCode
                     ]
                 )
             in
                 facts,
         cases = {
-            {400, "Bad Request", "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid."},
-            {401, "Authentication Error", "The username or password you have specified is invalid."},
-            {403, "Authorization Error", "You are not authorized to access the specified resource."},
-            {404, "Not Found", "The requested resource is not found."},
-            {500, "Server Error", "The source IP responded with a server error."}
+            {
+                400,
+                "Bad Request",
+                "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                4000
+            },
+            {
+                401,
+                "Authentication Error",
+                "Error 4010: The username or password you have specified is invalid.",
+                4010
+            },
+            {
+                403,
+                "Authorization Error",
+                "Error 4030: You are not authorized to access the specified resource.",
+                4030
+            },
+            {404, "Not Found", "Error 4040: The requested resource is not found.", 4040},
+            {429, "Snapshot Quota Error", "Error 4290: Snapshot quota exceeded.", 4290},
+            {500, "Server Error", "Error 5000: The source IP responded with a server error.", 5000}
         },
         facts = ProvideDataForTest(cases, AssertErrorIsRaised)
     in
@@ -378,7 +435,9 @@ TestFetchDataRaisesErrorWhenCountRequestFails = () =>
 
 TestFetchDataRaisesErrorWhenSnapshotRequestFails = () =>
     let
-        AssertErrorIsRaised = (statusCode as number, expectedReason as text, expectedMessage as text) =>
+        AssertErrorIsRaised = (
+            statusCode as number, expectedReason as text, expectedMessage as text, expectedErrorCode as number
+        ) =>
             let
                 fakeSnapshotResponse = FakeRawResponse([#"error" = "reason"], [
                     Response.Status = statusCode
@@ -399,18 +458,34 @@ TestFetchDataRaisesErrorWhenSnapshotRequestFails = () =>
                     [
                         ManuallyHandled = true,
                         Cause = [#"error" = "reason"],
-                        RequestUrl = "http://dummy_url/api/audit/sessions/_snapshot"
+                        RequestUrl = "http://dummy_url/api/audit/sessions/_snapshot",
+                        ErrorCode = expectedErrorCode
                     ]
                 )
             in
                 facts,
         cases = {
-            {400, "Bad Request", "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid."},
-            {401, "Authentication Error", "The username or password you have specified is invalid."},
-            {403, "Authorization Error", "You are not authorized to access the specified resource."},
-            {404, "Not Found", "The requested resource is not found."},
-            {429, "Snapshot Quota Error", "Snapshot quota exceeded."},
-            {500, "Server Error", "The source IP responded with a server error."}
+            {
+                400,
+                "Bad Request",
+                "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                4000
+            },
+            {
+                401,
+                "Authentication Error",
+                "Error 4010: The username or password you have specified is invalid.",
+                4010
+            },
+            {
+                403,
+                "Authorization Error",
+                "Error 4030: You are not authorized to access the specified resource.",
+                4030
+            },
+            {404, "Not Found", "Error 4040: The requested resource is not found.", 4040},
+            {429, "Snapshot Quota Error", "Error 4290: Snapshot quota exceeded.", 4290},
+            {500, "Server Error", "Error 5000: The source IP responded with a server error.", 5000}
         },
         facts = ProvideDataForTest(cases, AssertErrorIsRaised)
     in

--- a/SafeguardSessions/test/Integration/TestFetchSessions.query.pq
+++ b/SafeguardSessions/test/Integration/TestFetchSessions.query.pq
@@ -95,8 +95,8 @@ TestFetchSessionsWithOnlyOneFilterFieldInput = () =>
             HasError = true,
             Error = [
                 Reason = "Filter Field Without Value",
-                Message = "There is a field value missing from one or more of your filter fields.",
-                Detail = [ManuallyHandled = false, Cause = "protocol", RequestUrl = null],
+                Message = "Error 10000: There is a field value missing from one or more of your filter fields.",
+                Detail = [ManuallyHandled = false, Cause = "protocol", RequestUrl = null, ErrorCode = 10000],
                 Message.Format = null,
                 Message.Parameters = null
             ]
@@ -134,8 +134,8 @@ TestFetchingSessionsWithFromSPSWithUnsupportedVersion = () =>
             HasError = true,
             Error = [
                 Reason = "Not Supported Version",
-                Message = "Your version of the connector (v1.0.0+sps7.3.0) is not compatible with your SPS version (unsupported_version). For a connector version that is compatible with your SPS version, visit the official release page of the connector: https://github.com/OneIdentity/SafeguardPowerBI/releases",
-                Detail = [Version = "unsupported_version", SupportedVersions = "7.3", ManuallyHandled = false],
+                Message = "Error 10001: Your version of the connector (v1.0.0+sps7.3.0) is not compatible with your SPS version (unsupported_version). For a connector version that is compatible with your SPS version, visit the official release page of the connector: https://github.com/OneIdentity/SafeguardPowerBI/releases",
+                Detail = [Version = "unsupported_version", SupportedVersions = "7.3", ManuallyHandled = false, ErrorCode = 10001],
                 Message.Format = null,
                 Message.Parameters = null
             ]
@@ -307,18 +307,19 @@ TestFetchingSessions = () =>
                     & TestSafeguardSessions.Mocks,
                 [
                     Reason = "Bad Request",
-                    Message = "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                    Message = "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
                     Detail = [
                         ManuallyHandled = true,
                         Cause = [#"error" = "value"],
-                        RequestUrl = "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&q=apple%3Apeach&snapshot=dummy_snapshot_id"
+                        RequestUrl = "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&q=apple%3Apeach&snapshot=dummy_snapshot_id",
+                        ErrorCode = 4000
                     ],
                     Message.Format = null,
                     Message.Parameters = null
                 ],
                 FetchInfo(
                     "Error",
-                    "The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                    "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
                     null,
                     0,
                     true,

--- a/SafeguardSessions/test/Integration/TestGetData.query.pq
+++ b/SafeguardSessions/test/Integration/TestGetData.query.pq
@@ -271,18 +271,19 @@ TestGetDataHandlesAuthenticationError = () =>
         ]),
         expectedData = [
             Reason = "Authentication Error",
-            Message = "The username or password you have specified is invalid.",
+            Message = "Error 4010: The username or password you have specified is invalid.",
             Detail = [
                 ManuallyHandled = true,
                 Cause = [#"error" = "value"],
-                RequestUrl = "https://dummy_url/api/authentication"
+                RequestUrl = "https://dummy_url/api/authentication",
+                ErrorCode = 4010
             ],
             Message.Format = null,
             Message.Parameters = null
         ],
         expectedInfo = FetchInfo(
             "Error",
-            "The username or password you have specified is invalid.",
+            "Error 4010: The username or password you have specified is invalid.",
             null,
             0,
             true,
@@ -343,18 +344,19 @@ TestGetDataHandlesBadRequest = () =>
         ],
         expectedData = [
             Reason = "Server Error",
-            Message = "The source IP responded with a server error.",
+            Message = "Error 5000: The source IP responded with a server error.",
             Detail = [
                 ManuallyHandled = true,
                 Cause = [#"error" = "reason"],
-                RequestUrl = "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id"
+                RequestUrl = "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id",
+                ErrorCode = 5000
             ],
             Message.Format = null,
             Message.Parameters = null
         ],
         expectedInfo = FetchInfo(
             "Error",
-            "The source IP responded with a server error.",
+            "Error 5000: The source IP responded with a server error.",
             null,
             0,
             true,
@@ -439,8 +441,13 @@ TestGetDataReturnsWithErrorInCaseOfUnsupportedSPSVersion = () =>
             HasError = true,
             Error = [
                 Reason = "Not Supported Version",
-                Message = "Your version of the connector (v1.0.0+sps7.3.0) is not compatible with your SPS version (unsupported_version). For a connector version that is compatible with your SPS version, visit the official release page of the connector: https://github.com/OneIdentity/SafeguardPowerBI/releases",
-                Detail = [Version = "unsupported_version", SupportedVersions = "7.3", ManuallyHandled = false],
+                Message = "Error 10001: Your version of the connector (v1.0.0+sps7.3.0) is not compatible with your SPS version (unsupported_version). For a connector version that is compatible with your SPS version, visit the official release page of the connector: https://github.com/OneIdentity/SafeguardPowerBI/releases",
+                Detail = [
+                    Version = "unsupported_version",
+                    SupportedVersions = "7.3",
+                    ManuallyHandled = false,
+                    ErrorCode = 10001
+                ],
                 Message.Format = null,
                 Message.Parameters = null
             ]
@@ -472,8 +479,12 @@ TestGetDataReturnWithAnUnexpectedErrorBecauseSomethingUnexpectedHappendDuringAut
             HasError = true,
             Error = [
                 Reason = "Wrong variable",
-                Message = "Variable type mismatch error",
-                Detail = "The variable badVariable is of the type text, but it should be of the type number",
+                Message = "Error 99999: Variable type mismatch error",
+                Detail = [
+                    originalDetails = "The variable badVariable is of the type text, but it should be of the type number",
+                    ErrorCode = 99999,
+                    ManuallyHandled = false
+                ],
                 Message.Format = null,
                 Message.Parameters = null
             ]
@@ -506,8 +517,12 @@ TestGetDataReturnWithAnUnexpectedErrorBecauseSomethingUnexpectedHappendDuringDat
             HasError = true,
             Error = [
                 Reason = "Wrong variable",
-                Message = "Variable type mismatch error",
-                Detail = "The variable badVariable is of the type text, but it should be of the type number",
+                Message = "Error 99999: Variable type mismatch error",
+                Detail = [
+                    originalDetails = "The variable badVariable is of the type text, but it should be of the type number",
+                    ErrorCode = 99999,
+                    ManuallyHandled = false
+                ],
                 Message.Format = null,
                 Message.Parameters = null
             ]
@@ -542,18 +557,19 @@ TestGetDataHandlesSchemaApplyError = () =>
         ],
         expectedData = [
             Reason = "Schema Apply Error",
-            Message = "An error happened when applying schema.",
+            Message = "Error 10004: An error happened when applying schema.",
             Detail = [
                 Cause = TestSafeguardSessions.ActualResponseData,
                 RequestUrl = "https://dummy_url/api/audit/sessions?fields=%2A&sort=-start_time&snapshot=dummy_snapshot_id",
-                ManuallyHandled = true
+                ManuallyHandled = true,
+                ErrorCode = 10004
             ],
             Message.Format = null,
             Message.Parameters = null
         ],
         expectedInfo = FetchInfo(
             "Error",
-            "An error happened when applying schema.",
+            "Error 10004: An error happened when applying schema.",
             null,
             0,
             true,

--- a/SafeguardSessions/test/Unit/TestHandleIfThereIsAnError.query.pq
+++ b/SafeguardSessions/test/Unit/TestHandleIfThereIsAnError.query.pq
@@ -1,0 +1,86 @@
+section TestSafeguardSessions.HandleIfThereIsAnError;
+
+AssertVersionCheck = (description as text, input as record, expectedValue as record) =>
+    let
+        handled = try HandleIfThereIsAnError(input),
+        actualValue = if handled[HasError] = true then handled[Error] else handled[Value]
+    in
+        Fact(description, expectedValue, actualValue);
+
+TestHandleIfThereIsAnError = () =>
+    let
+        cases = {
+            {"Input is not an error", try ("Dummy"), [HasError = false, Value = "Dummy"]},
+            {
+                "Input is an unexpected error",
+                try
+                    (
+                        error
+                            [
+                                Reason = "Wrong variable",
+                                Message = "Variable type mismatch error",
+                                Detail = "The variable badVariable is of the type text, but it should be of the type number"
+                            ]
+                    ),
+                [
+                    Reason = "Wrong variable",
+                    Message = "Error 99999: Variable type mismatch error",
+                    Detail = [
+                        originalDetails = "The variable badVariable is of the type text, but it should be of the type number",
+                        ManuallyHandled = false,
+                        ErrorCode = 99999
+                    ],
+                    Message.Format = null,
+                    Message.Parameters = null
+                ]
+            },
+            {
+                "Input is a manually not handled error error",
+                try
+                    (
+                        error
+                            [
+                                Reason = "Filter Field Without Value",
+                                Message = "Error: 10000: There is a field value missing from one or more of your filter fields.",
+                                Detail = [Url = "dummy.url", ManuallyHandled = false, ErrorCode = 10000]
+                            ]
+                    ),
+                [
+                    Reason = "Filter Field Without Value",
+                    Message = "Error: 10000: There is a field value missing from one or more of your filter fields.",
+                    Detail = [Url = "dummy.url", ManuallyHandled = false, ErrorCode = 10000],
+                    Message.Format = null,
+                    Message.Parameters = null
+                ]
+            },
+            {
+                "Input is a manually handled error",
+                try
+                    (
+                        error
+                            [
+                                Reason = "Bad Request",
+                                Message = "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                                Detail = [Url = "dummy.url", ManuallyHandled = true, ErrorCode = 4000]
+                            ]
+                    ),
+                [
+                    HasError = true,
+                    Error = [
+                        Reason = "Bad Request",
+                        Message = "Error 4000: The source IP interpreted a malformed request. Your filter parameter(s) might be invalid.",
+                        Detail = [Url = "dummy.url", ManuallyHandled = true, ErrorCode = 4000],
+                        Message.Format = null,
+                        Message.Parameters = null
+                    ]
+                ]
+            }
+        },
+        facts = ProvideDataForTest(cases, AssertVersionCheck)
+    in
+        facts;
+
+shared TestRequestErrors.UnitTest = [
+    facts = {TestHandleIfThereIsAnError()},
+    report = Facts.Summarize(facts)
+][report];

--- a/SafeguardSessions/test/Unit/TestResponseHandler.query.pq
+++ b/SafeguardSessions/test/Unit/TestResponseHandler.query.pq
@@ -14,11 +14,12 @@ TestValidateByStatusCodeRaisesError = () =>
         facts = TestErrorIsRaised(
             try ValidateByStatusCode(fake_auth_response),
             "Authentication Error",
-            "The username or password you have specified is invalid.",
+            "Error 4010: The username or password you have specified is invalid.",
             [
                 ManuallyHandled = true,
                 Cause = fake_auth_response,
-                RequestUrl = url
+                RequestUrl = url,
+                ErrorCode = 4010
             ]
         )
     in
@@ -75,12 +76,13 @@ TestGetDataFromResponse = () =>
                     HasError = true,
                     Error = [
                         Reason = "Not Parsable Response",
-                        Message = "The source IP returned a response with missing fields.",
+                        Message = "Error 10002: The source IP returned a response with missing fields.",
                         Detail = [
                             ManuallyHandled = true,
                             Cause = fake_response,
                             MissingField = "",
-                            RequestUrl = "dummy_url"
+                            RequestUrl = "dummy_url",
+                            ErrorCode = 10002 
                         ],
                         Message.Format = null,
                         Message.Parameters = null
@@ -94,12 +96,13 @@ TestGetDataFromResponse = () =>
                     HasError = true,
                     Error = [
                         Reason = "Not Parsable Response",
-                        Message = "The source IP returned a response with missing fields.",
+                        Message = "Error 10002: The source IP returned a response with missing fields.",
                         Detail = [
                             ManuallyHandled = true,
                             Cause = fake_response,
                             MissingField = "body/svc1/protocol",
-                            RequestUrl = "dummy_url"
+                            RequestUrl = "dummy_url",
+                            ErrorCode = 10002
                         ],
                         Message.Format = null,
                         Message.Parameters = null

--- a/SafeguardSessions/test/Unit/TestSearch.query.pq
+++ b/SafeguardSessions/test/Unit/TestSearch.query.pq
@@ -102,11 +102,12 @@ TestAdvancedSearchRaisesError = () =>
             )
         ],
         expectedReason = "Not Found",
-        expectedMessage = "The requested resource is not found.",
+        expectedMessage = "Error 4040: The requested resource is not found.",
         expectedDetail = [
             ManuallyHandled = true,
             Cause = [#"error" = "reason"],
-            RequestUrl = "http://dummy_url/dummy_url_final"
+            RequestUrl = "http://dummy_url/dummy_url_final",
+            ErrorCode = 4040
         ]
     in
         TestErrorIsRaised(
@@ -138,12 +139,13 @@ TestGetSessionsCountRaisesError = () =>
             RequestUrl = requestUrl
         ]),
         expectedReason = "Not Parsable Response",
-        expectedMessage = "The source IP returned a response with missing fields.",
+        expectedMessage = "Error 10002: The source IP returned a response with missing fields.",
         expectedDetail = [
-            ManuallyHandled = true,
             Cause = [invalid = "response"],
             MissingField = "count",
-            RequestUrl = requestUrl
+            RequestUrl = requestUrl,
+            ManuallyHandled = true,
+            ErrorCode = 10002
         ]
     in
         TestErrorIsRaised(
@@ -194,11 +196,12 @@ TestOpenSnapshotRaisesError = () =>
             {
                 FakeRawResponse([invalid = "response"]),
                 "Not Parsable Response",
-                "The source IP returned a response with missing fields.",
+                "Error 10002: The source IP returned a response with missing fields.",
                 [
-                    ManuallyHandled = true,
                     Cause = [invalid = "response"],
-                    MissingField = "body.snapshot"
+                    MissingField = "body.snapshot", 
+                    ManuallyHandled = true,
+                    ErrorCode = 10002
                 ]
             },
             {
@@ -206,10 +209,11 @@ TestOpenSnapshotRaisesError = () =>
                     Response.Status = 429
                 ]),
                 "Snapshot Quota Error",
-                "Snapshot quota exceeded.",
+                "Error 4290: Snapshot quota exceeded.",
                 [
+                    Cause = [#"error" = "reason"],
                     ManuallyHandled = true,
-                    Cause = [#"error" = "reason"]
+                    ErrorCode = 4290
                 ]
             }
         },

--- a/SafeguardSessions/test/Unit/TestUrlBuilder.query.pq
+++ b/SafeguardSessions/test/Unit/TestUrlBuilder.query.pq
@@ -75,8 +75,8 @@ TestGenerateUrl = () =>
                     HasError = true,
                     Error = [
                         Reason = "Filter Field Without Value",
-                        Message = "There is a field value missing from one or more of your filter fields.",
-                        Detail = [ManuallyHandled = false, Cause = "protocol", RequestUrl = null],
+                        Message = "Error 10000: There is a field value missing from one or more of your filter fields.",
+                        Detail = [ManuallyHandled = false, Cause = "protocol", RequestUrl = null, ErrorCode=10000],
                         Message.Format = null,
                         Message.Parameters = null
                     ]

--- a/SafeguardSessions/test/Unit/schema/TestFlatten.query.pq
+++ b/SafeguardSessions/test/Unit/schema/TestFlatten.query.pq
@@ -54,11 +54,12 @@ TestFlattenListsHandlesListWithNonTextValue = () =>
             TestErrorIsRaised(
                 cellValue,
                 "List To Text Conversion Error",
-                "The list contains other types than text.",
+                "Error 10003: The list contains other types than text.",
                 [
-                    ManuallyHandled = true,
                     Cause = "[""3"",4]",
-                    RequestUrl = null
+                    RequestUrl = null,
+                    ManuallyHandled = true,
+                    ErrorCode = 10003
                 ]
             ),
             Fact(

--- a/SafeguardSessions/test/Unit/version/TestGetVersion.query.pq
+++ b/SafeguardSessions/test/Unit/version/TestGetVersion.query.pq
@@ -23,9 +23,10 @@ TestGetVersionRaisesError = () =>
             RequestUrl = requestUrl
         ]),
         expectedReason = "Not Parsable Response",
-        expectedMessage = "The source IP returned a response with missing fields.",
+        expectedMessage = "Error 10002: The source IP returned a response with missing fields.",
         expectedDetail = [
             ManuallyHandled = true,
+            ErrorCode =  10002,
             Cause = [invalid = "response"],
             MissingField = "body.firmware_version",
             RequestUrl = requestUrl


### PR DESCRIPTION
Scope: SafeguardSessions\modules\error

The introduction of error codes is necessary to easily identify errors regardless of the language of the Power BI interface. When creating error codes, the following convention has been introduced:

 * HTTP request error codes have been extended with a 0
 * Errors originating from the Power BI Connector start at 10000, and there are currently no subcategories for them

I transformed the unexpected error with the custom function 'TransformUnexpectedError' in the newly made 'UnexpectedErrorWarper' module. This function will convert the unexpected error to an 'ErrorBase' type error because this will help handle all errors in a uniform way. To do this, I moved the Detail field of the original record to an internal record field. This was necessary because the value of the Detail field is not necessarily a record.

References: azure #415680