### PR TITLE
sps: Fix GetDataFromResponse function meta and error handling

### DIFF
--- a/SafeguardSessions/modules/request/ResponseHandler.pqm
+++ b/SafeguardSessions/modules/request/ResponseHandler.pqm
@@ -2,15 +2,18 @@ let
     Logger.ErrorLog = Extension.ImportFunction("ErrorLog", "Logger.pqm"),
     RequestErrors.ErrorMap = Extension.ImportFunction("ErrorMap", "RequestErrors.pqm"),
     RequestErrors.NotParsableResponse = Extension.ImportFunction("NotParsableResponse", "RequestErrors.pqm"),
-
     ResponseHandler.GetDataFromResponse = (response as record, path as text, optional separator as text) =>
         let
-            GetRecordSafe = (response as record, pathAsList as list) =>
+            GetRecordSafe = (content as record, pathAsList as list) =>
                 let
                     currentField = List.First(pathAsList),
-                    currentResponse = if currentField <> -1 then Record.FieldOrDefault(response, currentField, null) else response,
-                    handledResponse =
-                        if currentResponse = null then
+                    currentContent =
+                        if currentField <> -1 then
+                            Record.FieldOrDefault(content, currentField, null) meta Value.Metadata(response)
+                        else
+                            content,
+                    handledContent =
+                        if currentContent = null then
                             RequestErrors.NotParsableResponse(
                                 [
                                     Cause = response,
@@ -19,9 +22,13 @@ let
                                 ]
                             )
                         else
-                            currentResponse,
+                            currentContent,
                     nextPathAsList = List.RemoveFirstN(pathAsList, 1),
-                    result = if List.Count(nextPathAsList) > 0 then @GetRecordSafe(handledResponse, nextPathAsList) else handledResponse
+                    result =
+                        if List.Count(nextPathAsList) > 0 then
+                            @GetRecordSafe(handledContent, nextPathAsList)
+                        else
+                            handledContent
                 in
                     result,
             _separator = separator ?? ".",
@@ -31,7 +38,7 @@ let
             data,
     ResponseHandler.ValidateByStatusCode = (response as record) =>
         let
-           responseMeta = Value.Metadata(response),
+            responseMeta = Value.Metadata(response),
             httpStatus = Text.From(responseMeta[Response.Status]),
             log = Logger.ErrorLog(
                 "SPS returned with an error response",

--- a/SafeguardSessions/test/Unit/TestResponseHandler.query.pq
+++ b/SafeguardSessions/test/Unit/TestResponseHandler.query.pq
@@ -7,17 +7,17 @@ ValidateByStatusCode = Extension.ImportFunction("ValidateByStatusCode", "Respons
 TestValidateByStatusCodeRaisesError = () =>
     let
         url = "dummy_url",
-        fake_auth_response = FakeResponse([#"error" = "reason"], [
+        fakeAuthResponse = FakeResponse([#"error" = "reason"], [
             Response.Status = 401,
             RequestUrl = url
         ]),
         facts = TestErrorIsRaised(
-            try ValidateByStatusCode(fake_auth_response),
+            try ValidateByStatusCode(fakeAuthResponse),
             "Authentication Error",
             "Error 4010: The username or password you have specified is invalid.",
             [
                 ManuallyHandled = true,
-                Cause = fake_auth_response,
+                Cause = fakeAuthResponse,
                 RequestUrl = url,
                 ErrorCode = 4010
             ]
@@ -27,10 +27,10 @@ TestValidateByStatusCodeRaisesError = () =>
 
 TestValidateByStatusCodeFallbackIsWorking = () =>
     let
-        fake_response = FakeResponse([key = "value"]) meta [RequestUrl = "dummy_url"],
-        response = ValidateByStatusCode(fake_response),
+        fakeResponse = FakeResponse([key = "value"]) meta [RequestUrl = "dummy_url"],
+        response = ValidateByStatusCode(fakeResponse),
         facts = {
-            Fact("Response data correct", fake_response, response),
+            Fact("Response data correct", fakeResponse, response),
             Fact(
                 "Response meta is correct",
                 [
@@ -46,32 +46,61 @@ TestValidateByStatusCodeFallbackIsWorking = () =>
 
 TestGetDataFromResponse = () =>
     let
-        fake_response = FakeResponse([
+        fakeResponse = FakeResponse([
             body = [
                 svc1 = [protocol = "ssh"]
             ],
             #"meta" = [next = "the/next/link"]
         ]) meta [RequestUrl = "dummy_url"],
-        cases = {
+        GetDataAndMeta = (response as record, path as text, optional separator as text) =>
+            let
+                data = GetDataFromResponse(response, path, separator), dataMeta = Value.Metadata(data)
+            in
+                [Data = data, Meta = dataMeta],
+        AssertDataAndMeta = (
+            description as text,
+            expected_response_with_meta as record,
+            response as record,
+            path as text,
+            optional separator as text
+        ) =>
+            let
+                data = GetDataFromResponse(response, path, separator), dataMeta = Value.Metadata(data)
+            in
+                Fact(description, expected_response_with_meta, [Data = data, Meta = dataMeta]),
+        validCases = {
             {
-                "Returns one-level deep data from response",
+                "Returns one-level deep data with meta from response",
                 [
-                    next = "the/next/link"
+                    Data = [next = "the/next/link"],
+                    Meta = [Content.Type = "application/json", Response.Status = 200, RequestUrl = "dummy_url"]
                 ],
-                GetDataFromResponse(fake_response, "meta")
+                fakeResponse,
+                "meta"
             },
             {
                 "Returns multiple-level deep data from response",
-                "ssh",
-                GetDataFromResponse(fake_response, "body.svc1.protocol")
+                [
+                    Data = "ssh",
+                    Meta = [Content.Type = "application/json", Response.Status = 200, RequestUrl = "dummy_url"]
+                ],
+                fakeResponse,
+                "body.svc1.protocol"
             },
             {
                 "Returns data from response when path is specified with custom separator",
-                "ssh",
-                GetDataFromResponse(fake_response, "body/svc1/protocol", "/")
-            },
+                [
+                    Data = "ssh",
+                    Meta = [Content.Type = "application/json", Response.Status = 200, RequestUrl = "dummy_url"]
+                ],
+                fakeResponse,
+                "body/svc1/protocol",
+                "/"
+            }
+        },
+        errorCases = {
             {
-                "Raises error if path not found in response",
+                "Raises error if first part of the path is not found in response",
                 [
                     HasError = true,
                     Error = [
@@ -79,16 +108,36 @@ TestGetDataFromResponse = () =>
                         Message = "Error 10002: The source IP returned a response with missing fields.",
                         Detail = [
                             ManuallyHandled = true,
-                            Cause = fake_response,
+                            Cause = fakeResponse,
                             MissingField = "",
                             RequestUrl = "dummy_url",
-                            ErrorCode = 10002 
+                            ErrorCode = 10002
                         ],
                         Message.Format = null,
                         Message.Parameters = null
                     ]
                 ],
-                try GetDataFromResponse(fake_response, "")
+                try GetDataFromResponse(fakeResponse, "")
+            },
+            {
+                "Raises error if inner part of the path is not found in response",
+                [
+                    HasError = true,
+                    Error = [
+                        Reason = "Not Parsable Response",
+                        Message = "Error 10002: The source IP returned a response with missing fields.",
+                        Detail = [
+                            ManuallyHandled = true,
+                            Cause = fakeResponse,
+                            MissingField = "body.svc.dummy",
+                            RequestUrl = "dummy_url",
+                            ErrorCode = 10002
+                        ],
+                        Message.Format = null,
+                        Message.Parameters = null
+                    ]
+                ],
+                try GetDataFromResponse(fakeResponse, "body.svc.dummy")
             },
             {
                 "Raises error when path not splitted due to different separator what path includes and retrieval not finds the unsplitted field",
@@ -99,7 +148,7 @@ TestGetDataFromResponse = () =>
                         Message = "Error 10002: The source IP returned a response with missing fields.",
                         Detail = [
                             ManuallyHandled = true,
-                            Cause = fake_response,
+                            Cause = fakeResponse,
                             MissingField = "body/svc1/protocol",
                             RequestUrl = "dummy_url",
                             ErrorCode = 10002
@@ -108,10 +157,12 @@ TestGetDataFromResponse = () =>
                         Message.Parameters = null
                     ]
                 ],
-                try GetDataFromResponse(fake_response, "body/svc1/protocol", ".")
+                try GetDataFromResponse(fakeResponse, "body/svc1/protocol", ".")
             }
         },
-        facts = ProvideDataForTest(cases, Fact)
+        validFacts = ProvideDataForTest(validCases, AssertDataAndMeta),
+        errorFacts = ProvideDataForTest(errorCases, Fact),
+        facts = {validFacts, errorFacts}
     in
         facts;
 


### PR DESCRIPTION
Scope: SafeguardSessions\modules\request\ResponseHandler.pqm

Previously, when the GetDataFromResponse's inner GetRecordSafe function was recursively called, the meta from the original response input was not passed on, so when an internal field of the path was not found, the function could not pass the meta field of the original response RequestURL to the RequestErrors.NotParsableResponse.

This has been fixed, so the output of GetRecordSafe will contain the meta of the original respond. For the raised error, we will use the response value given to GetDataFromResponse because if we use the input record of GetRecordSafe, we would lose more and more of the original response during recursion because we only pass on the value of the internal field that was found.

References: azure #426661