### PR TITLE
sps: Add checksum handling targets to build system

### DIFF
--- a/SafeguardSessions/Makefile
+++ b/SafeguardSessions/Makefile
@@ -12,7 +12,27 @@ TEST_PROJECT_CONFIG=$(TEST_CONNECTOR_DIR)\test.proj
 MAIN_CONNECTOR=bin\OneIdentitySafeguard.mez
 TEST_FRAMEWORK=$(TEST_CONNECTOR_DIR)\bin\UnitTestFramework.mez
 
+REPORT_TEMPLATE=assets/template/OneIdentitySafeguard.pbit
+
 SHORT?=true
+
+define calculate_checksum
+	(Get-FileHash "$(1)" -Algorithm SHA256).Hash.ToLower()
+endef
+
+define write_checksum
+	Out-File \
+		-FilePath '$(1).sha256' \
+		-Encoding ASCII \
+		-InputObject \$\($(call calculate_checksum,$(1))\)
+endef
+
+define write_checksum
+	Out-File \
+		-FilePath '$(1).sha256' \
+		-Encoding ASCII \
+		-InputObject \$\($(call calculate_checksum,$(1))\)
+endef
 
 build:
 	MSBuild $(TEST_PROJECT_CONFIG) -t:Clean;BuildMez \
@@ -33,3 +53,13 @@ unit-tests:
 	--environmentConfiguration short=$(SHORT) \
 	--queryFile $(TEST_CONNECTOR_DIR) \
 	--prettyPrint
+
+checksum:
+	@powershell $(call write_checksum,$(MAIN_CONNECTOR))
+	@powershell $(call write_checksum,$(REPORT_TEMPLATE))
+
+verify-checksum:
+	@powershell (Get-Content -Path $(MAIN_CONNECTOR).sha256) -eq \
+		$(call calculate_checksum,$(MAIN_CONNECTOR))
+	@powershell (Get-Content -Path $(REPORT_TEMPLATE).sha256) -eq \
+		$(call calculate_checksum,$(REPORT_TEMPLATE))


### PR DESCRIPTION
Scope: SafeguardSessions/Makefile

To stream line release process (and a preparation to automating it) we added new `make checksum` target, that calculates SHA256 checksums for build artifacts and report template.

Using `make verify-checksum` target can ensure these checksums are up-to-date.

References: azure #427269