### PR TITLE
sps: Fix an empty table should also return with schema

### DIFF
--- a/SafeguardSessions/Src/Modules/Search.pqm
+++ b/SafeguardSessions/Src/Modules/Search.pqm
@@ -5,7 +5,9 @@ let
     SessionsSnapshotEndpoint = Extension.ImportFunction("SessionsSnapshotEndpoint", "Constants.pqm"),
     Request.Generate = Extension.ImportFunction("Generate", "Request.pqm"),
     Request.GetDefaultParameters = Extension.ImportFunction("GetDefaultParameters", "Request.pqm"),
-    ResponseHandler.GetDataFromResponse = Extension.ImportFunction("GetDataFromResponse", "CommonResponseHandler.pqm"),
+    ResponseHandler.GetDataFromResponse = Extension.ImportFunction(
+        "GetDataFromResponse", "CommonResponseHandler.pqm"
+    ),
     ResponseHandler.ValidateByStatusCode = Extension.ImportFunction("ValidateByStatusCode", "ResponseHandler.pqm"),
     UrlBuilder.GenerateUrl = Extension.ImportFunction("GenerateUrl", "UrlBuilder.pqm"),
     Schema.GetSchema = Extension.ImportFunction("GetSchema", "Schema.pqm"),
@@ -99,25 +101,19 @@ let
             page,
     Search.GenerateByPage = (getNextPage as function) as table =>
         let
-            listOfPages = List.Select(
-                List.Generate(
-                    () => getNextPage(null),
-                    (lastPage) => lastPage <> null,
-                    (lastPage) => getNextPage(lastPage)
-                ),
-                each not Table.IsEmpty(_)
+            listOfPages = List.Generate(
+                () => getNextPage(null), (lastPage) => lastPage <> null, (lastPage) => getNextPage(lastPage)
             ),
             tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Page"}),
-            firstRow = tableOfPages{0}?,
+            firstRow = tableOfPages{0},
             combined = Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Page", Table.ColumnNames(firstRow[Page])),
                 Value.Type(firstRow[Page])
             )
         in
-            if firstRow = null then
-                Table.FromRows({})
-            else
-                combined
+            Table.SelectRows(
+                combined, each not List.IsEmpty(List.RemoveMatchingItems(Record.FieldValues(_), {null}))
+            )
 in
     [
         AdvancedSearch = Search.AdvancedSearch,

--- a/SafeguardSessions/Test/Unit/TestSearch.query.pq
+++ b/SafeguardSessions/Test/Unit/TestSearch.query.pq
@@ -89,6 +89,35 @@ TestAdvancedSearchIsSuccessful = () =>
     in
         Fact("Advance search returns all pages", expectedData, result);
 
+TestAdvancedSearchWithZeroItem = () =>
+    let
+        fakeResponses = [
+            #"http://dummy_url/api/audit/sessions?snapshot=dummy_snapshot" = TestSafeguardSessions.Response.Last,
+            #"http://dummy_url/dummy_url_final" = TestSafeguardSessions.Response.Last
+        ],
+        expectedData = #table(
+            type table [
+                session_id = text,
+                subtable.field1 = number,
+                subtable.field2 = text,
+                flatvalue1 = number,
+                flatvalue2 = logical
+            ],
+            {}
+        ),
+        result = Search.AdvancedSearch(
+            "dummy_url",
+            [],
+            "dummy_snapshot",
+            "dummy_session_id",
+            [
+                GetPageResponseMap = fakeResponses,
+                Schema = TestSafeguardSessions.Schema
+            ]
+        )
+    in
+        Fact("Advance search returns an empty table with schema", expectedData, result);
+
 TestErrorIsContainedInAdvancedSearchResponse = () =>
     let
         fakeResponses = [
@@ -106,7 +135,10 @@ TestErrorIsContainedInAdvancedSearchResponse = () =>
             [],
             "dummy_snapshot",
             "dummy_session_id",
-            [GetPageResponseMap = fakeResponses, Schema = TestSafeguardSessions.Schema]
+            [
+                GetPageResponseMap = fakeResponses,
+                Schema = TestSafeguardSessions.Schema
+            ]
         ),
         expectedReason = "Not Found",
         expectedMessage = "Error 4040: The requested resource is not found.",
@@ -119,21 +151,28 @@ TestErrorIsContainedInAdvancedSearchResponse = () =>
         dataFacts = {
             Fact(
                 "First row contains valid data",
-                [ session_id = "id1", subtable.field1 = 1, subtable.field2 = "value1", flatvalue1 = 1, flatvalue2 = true ],
+                [
+                    session_id = "id1",
+                    subtable.field1 = 1,
+                    subtable.field2 = "value1",
+                    flatvalue1 = 1,
+                    flatvalue2 = true
+                ],
                 actualResponse{0}
             ),
             Fact(
                 "Second row contains valid data",
-                [ session_id = "id2", subtable.field1 = 2, subtable.field2 = "value2", flatvalue1 = 2, flatvalue2 = false ],
+                [
+                    session_id = "id2",
+                    subtable.field1 = 2,
+                    subtable.field2 = "value2",
+                    flatvalue1 = 2,
+                    flatvalue2 = false
+                ],
                 actualResponse{1}
             )
         },
-        errorFacts = TestErrorIsRaised(
-            try actualResponse{2},
-            expectedReason,
-            expectedMessage,
-            expectedDetail
-        )
+        errorFacts = TestErrorIsRaised(try actualResponse{2}, expectedReason, expectedMessage, expectedDetail)
     in
         List.Combine({dataFacts, errorFacts});
 
@@ -216,7 +255,7 @@ TestOpenSnapshotRaisesError = () =>
                 "Error 10002: The source IP returned a response with missing fields.",
                 [
                     Cause = [invalid = "response"],
-                    MissingField = "body.snapshot", 
+                    MissingField = "body.snapshot",
                     ManuallyHandled = true,
                     ErrorCode = 10002
                 ]
@@ -241,6 +280,7 @@ TestOpenSnapshotRaisesError = () =>
 shared Testsearch.UnitTest = [
     facts = {
         TestAdvancedSearchIsSuccessful(),
+        TestAdvancedSearchWithZeroItem(),
         TestErrorIsContainedInAdvancedSearchResponse(),
         TestGetSessionsCountIsSuccesful(),
         TestGetSessionsCountRaisesError(),


### PR DESCRIPTION
Scope: SafeguardSessions/Src/Modules/Search.pqm

Previously, if the SPS session query returned only one response that was empty, the connector only returned an empty Sessions table without the schema. And this caused an error with the template because the template already contained the Sessions table schema.

This has been fixed, so empty table will contain the Sessions schema.

References: azure #435254