### PR TITLE
sps: Fix bootstrap script

### DIFF
--- a/SafeguardSessions/Scripts/Bootstrap.ps1
+++ b/SafeguardSessions/Scripts/Bootstrap.ps1
@@ -52,7 +52,7 @@ try {
         Invoke-WebRequest -Uri https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1 -OutFile $(Get-Alias -Name dotnet-install).Definition
     }
 
-    & dotnet-install -InstallDir $DOTNET -NoCdn -NoPath -Runtime dotnet -Verbose -Version $packageVersions.DotnetVersion
+    & dotnet-install -InstallDir $DOTNET -NoCdn -NoPath -Verbose -Version $packageVersions.DotnetVersion
 
     Write-Output "Downloading nuget executable"
     if (-Not (Test-Path($(Get-Alias -Name nuget).Definition))) {

--- a/SafeguardSessions/packageVersions.json
+++ b/SafeguardSessions/packageVersions.json
@@ -1,5 +1,5 @@
 {
-    "DotnetVersion": "6.0.22",
+    "DotnetVersion": "7.0.402",
     "NugetVersion": "6.7.0",
     "PowerQuerySdkVersion": "2.114.4"
 }


### PR DESCRIPTION
Scope: SafeguardSessions/Scripts/Bootstrap.ps1

It is not enough to only install the dotnet runtime, the whole SDK is needed to be able to build the connector.

The .NET SDK version has been also updated.

References: azure #412931